### PR TITLE
Remove program mapping; still under developement

### DIFF
--- a/tools/branches.yaml
+++ b/tools/branches.yaml
@@ -204,10 +204,10 @@ projects:
     - ['lp:openerp-product-variant/7.0', master]
     - ['lp:openerp-product-variant/7.0', '7.0']
     - ['lp:openerp-product-variant/6.1', '6.1']
-  - github: git@github.com:OCA/program.git
-    branches:
-    - ['lp:openerp-program/7.0', master]
-    - ['lp:openerp-program/7.0', '7.0']
+  # - github: git@github.com:OCA/program.git
+  #  branches:
+  #  - ['lp:openerp-program/7.0', master]
+  #  - ['lp:openerp-program/7.0', '7.0']
   - github: git@github.com:OCA/reporting-engine.git
     branches:
     - ['lp:openerp-reporting-engines/7.0', master]


### PR DESCRIPTION
Program modules are still being heavily developped by Savoir-faire Linux

We decided to move forward using git.

This shouldn't impact anyone else, as I don't think anyone has been using this 
incomplete module
