### PR TITLE
Load OCA image via HTTPS

### DIFF
--- a/template/module/README.rst
+++ b/template/module/README.rst
@@ -49,9 +49,9 @@ Contributors
 Maintainer
 ----------
 
-.. image:: http://odoo-community.org/logo.png
+.. image:: https://odoo-community.org/logo.png
    :alt: Odoo Community Association
-   :target: http://odoo-community.org
+   :target: https://odoo-community.org
 
 This module is maintained by the OCA.
 


### PR DESCRIPTION
This little change avoid HTTPS broken pages in Odoo when user goes to addon details view