### PR TITLE
Add bug tracker in template in order to teach users where to report t…

### DIFF
--- a/template/module/README.rst
+++ b/template/module/README.rst
@@ -42,7 +42,7 @@ Bug Tracker
 
 Bugs are tracked on GitHub.
 In case of trouble, please check `there <https://www.github.com/OCA/{project_repo}/issues>`_ if your issue has already been reported.
-If you spotted it first, help us smashing it by providing a detailed and welcomed feedback `here <https://www.github.com/OCA/{project_repo}/issues/new>`_.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback `here <https://www.github.com/OCA/{project_repo}/issues/new?body=module: {module_name}%0Aversion: {version}%0A%0A**Steps to reproduce**%0A- ...%0A%0A**Current behavior**%0A%0A**Expected behavior**>`_.
 
 
 Credits

--- a/template/module/README.rst
+++ b/template/module/README.rst
@@ -40,8 +40,8 @@ Known issues / Roadmap
 Bug Tracker
 ===========
 
-Bugs are tracked on GitHub.
-In case of trouble, please check `there <https://github.com/OCA/{project_repo}/issues>`_ if your issue has already been reported.
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/{project_repo}/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed feedback `here <https://github.com/OCA/{project_repo}/issues/new?body=module: {module_name}%0Aversion: {version}%0A%0A**Steps to reproduce**%0A- ...%0A%0A**Current behavior**%0A%0A**Expected behavior**>`_.
 
 

--- a/template/module/README.rst
+++ b/template/module/README.rst
@@ -43,7 +43,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues <https://github.com/OCA/{project_repo}/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
-`here <https://github.com/OCA/{project_repo}/issues/new?body=module: {module_name}%0Aversion: {version}%0A%0A**Steps to reproduce**%0A- ...%0A%0A**Current behavior**%0A%0A**Expected behavior**>`_.
+`here <https://github.com/OCA/{project_repo}/issues/new?body=module:%20{module_name}%0Aversion:%20{version}%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 
 Credits

--- a/template/module/README.rst
+++ b/template/module/README.rst
@@ -37,6 +37,14 @@ Known issues / Roadmap
 
 * ...
 
+Bug Tracker
+===========
+
+Bugs are tracked on GitHub.
+In case of trouble, please check `there <https://www.github.com/OCA/{project_repo}/issues>`_ if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback `here <https://www.github.com/OCA/{project_repo}/issues/new>`_.
+
+
 Credits
 =======
 

--- a/template/module/README.rst
+++ b/template/module/README.rst
@@ -41,8 +41,8 @@ Bug Tracker
 ===========
 
 Bugs are tracked on GitHub.
-In case of trouble, please check `there <https://www.github.com/OCA/{project_repo}/issues>`_ if your issue has already been reported.
-If you spotted it first, help us smashing it by providing a detailed and welcomed feedback `here <https://www.github.com/OCA/{project_repo}/issues/new?body=module: {module_name}%0Aversion: {version}%0A%0A**Steps to reproduce**%0A- ...%0A%0A**Current behavior**%0A%0A**Expected behavior**>`_.
+In case of trouble, please check `there <https://github.com/OCA/{project_repo}/issues>`_ if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback `here <https://github.com/OCA/{project_repo}/issues/new?body=module: {module_name}%0Aversion: {version}%0A%0A**Steps to reproduce**%0A- ...%0A%0A**Current behavior**%0A%0A**Expected behavior**>`_.
 
 
 Credits

--- a/template/module/README.rst
+++ b/template/module/README.rst
@@ -42,7 +42,8 @@ Bug Tracker
 
 Bugs are tracked on `GitHub Issues <https://github.com/OCA/{project_repo}/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
-If you spotted it first, help us smashing it by providing a detailed and welcomed feedback `here <https://github.com/OCA/{project_repo}/issues/new?body=module: {module_name}%0Aversion: {version}%0A%0A**Steps to reproduce**%0A- ...%0A%0A**Current behavior**%0A%0A**Expected behavior**>`_.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/{project_repo}/issues/new?body=module: {module_name}%0Aversion: {version}%0A%0A**Steps to reproduce**%0A- ...%0A%0A**Current behavior**%0A%0A**Expected behavior**>`_.
 
 
 Credits


### PR DESCRIPTION
…heir issues instead of doing it on unread rating of app.odoo.com

Ok apps.odoo.com may not be used a lot, anyway what we got now is users rating modules with bad notes instead of creating issues.

https://www.odoo.com/apps/modules/8.0/picking_dispatch/
https://www.odoo.com/apps/modules/8.0/asterisk_click2dial/
https://www.odoo.com/apps/modules/8.0/travel_rental_car/

This aims to redirect them to where we track the bugs.

Rewording is welcome if you think of something better.


Link to new issue is a pre filled issue with title letted empty to be filled

Here is an example
https://github.com/OCA/connector/issues/new?body=module:%20connector%20%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**


Once merged, please merge the following PRs:

- [ ] OCA/vertical-edition#6
- [ ] OCA/account-financial-tools#217
- [ ] OCA/vertical-ngo#181
- [ ] OCA/l10n-belgium#21
- [ ] OCA/purchase-workflow#135
- [ ] OCA/l10n-germany#13
- [ ] OCA/l10n-switzerland#135
- [ ] OCA/l10n-canada#67
- [ ] OCA/report-print-send#29
- [ ] OCA/connector#70
- [ ] OCA/pos#28
- [ ] OCA/product-attribute#73
- [ ] OCA/reporting-engine#12
- [ ] OCA/sale-workflow#163
- [ ] OCA/bank-payment#167
- [ ] OCA/l10n-italy#112
- [ ] OCA/l10n-france#26
- [ ] OCA/stock-logistics-tracking#6
- [ ] OCA/l10n-netherlands#17
- [ ] OCA/connector-interfaces#16
- [ ] OCA/stock-logistics-workflow#112
- [ ] OCA/commission#19
- [ ] OCA/web#138
- [ ] OCA/account-invoicing#79
- [ ] OCA/management-system#74
- [ ] OCA/connector-ecommerce#20
- [ ] OCA/server-tools#170
