### PR TITLE
Fix guidelines for lambda default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -347,7 +347,7 @@ partner_id = partners[0].id
   pointer directly to the `default` parameter does not allow for inheritance.
 
   ```python
-  a_field(..., default=lambda self: self._default_get)
+  a_field(..., default=lambda self: self._default_get())
   ```
 
 * In a Model attribute order should be


### PR DESCRIPTION
I think the proposed lambda should call the default method, not return it.