### PR TITLE
Add guideline for version numbers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,19 +20,21 @@ section.
 ### Version numbers
 
 The version number in the module manifest should be the Odoo major
-version (e.g. `8.0`) followed by the module `x.y` version numbers.
-For example: `8.0.1.0` is expected for the first release of an 8.0
+version (e.g. `8.0`) followed by the module `x.y.z` version numbers.
+For example: `8.0.1.0.0` is expected for the first release of an 8.0
 module.
 
-The `x.y` version numbers follow the semantics `breaking.feature`:
-  * `x` increments when changes can break modules extending on it
-  * `y` increments when non-breaking new features are added
+The `x.y.z` version numbers follow the semantics `breaking.feature.fix`:
+  * `x` increments when the data model or the views had significant
+    changes. Data migration might be needed, or depending modules might
+    be affected.
+  * `y` increments when non-breaking new features are added. A module
+    upgrade will probably be needed.
+  * `z` increments when bugfixes were made. Usually a server restart
+    is needed for the fixes to be made available.
 
-If applicable, breaking changes are expected to include instruction
+If applicable, breaking changes are expected to include instructions
 or scripts to perform migration on current installations.
-
-Unless fitting in the above criteria, bugfixes are not required
-to increment module version numbers.
 
 
 ### Directories

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,24 @@ section.
   that is already in the plural (i.e. mrp_operations_....).
 * Use the [description template](https://github.com/OCA/maintainer-tools/tree/master/template/module)
 
+### Version numbers
+
+The version number in the module manifest should be the Odoo major
+version (e.g. `8.0`) followed by the module `x.y` version numbers.
+For example: `8.0.1.0` is expected for the first release of an 8.0
+module.
+
+The `x.y` version numbers follow the semantics `breaking.feature`:
+  * `x` increments when changes can break modules extending on it
+  * `y` increments when non-breaking new features are added
+
+If applicable, breaking changes are expected to include instruction
+or scripts to perform migration on current installations.
+
+Unless fitting in the above criteria, bugfixes are not required
+to increment module version numbers.
+
+
 ### Directories
 
 A module is organised in a few directory:


### PR DESCRIPTION
Rationale:

It is unfortunate that most modules don't include in the manifest the information of the major Odoo version they target. This is an important information since most of the time modules are incompatible with other Odoo version other than the one they target.
For example: it is frequent to find code in Github with an Odoo module in a "master" branch, but can't be sure of what Odoo version it targets by looking at it's manifest file.

This is so because in the past Odoo/Openerp automatically added the major version to module versions. Thus if your module was version "6.1.1", it would be displayed as "6.1.6.1.1".

It is no longer the case: [now](https://github.com/odoo/odoo/blob/8.0/openerp/modules/module.py#L368) Odoo does not do that if the major version is already appended to the module version!

Thus the Odoo target version can be included in the module version without being duplicated by the loading functions, and properly document the module's Odoo target version.