### PR TITLE
[REF] CONTRIBUTING.md: Add external dependencies case.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -258,6 +258,10 @@ except ImportError:
   _logger.info('Can not `import external_dependency_python_N`.')
 ```
 
+#### README
+If your module use extras dependencies of python or binaries, please explain how to install them in the `README.rst` file in the section `Installation`.
+
+
 ## Python
 
 ### PEP8 options

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,6 +219,45 @@ name.
 </record>
 ```
 
+### External dependencies
+
+#### `__openerp__.py`
+If your module use extras dependencies of python or binaries you should add to `__openerp__py` file the section `external_dependencies`.
+
+```python
+{
+    'name': 'Module of example',
+    'depends': ['base'],
+    ...
+    'external_dependencies': {
+        'bin': [
+            'external_dependency_binary_1',
+            'external_dependency_binary_2',
+            ...
+            'external_dependency_binary_N',
+        ],
+        'python': [
+            'external_dependency_python_1',
+            'external_dependency_python_2',
+            ...
+            'external_dependency_python_N',
+        ],
+    },
+    ...
+    'installable': True,
+}
+```
+
+#### ImportError
+In python files where you use a `import external_dependency_python_N` you will need to add a `try-except` with a info log.
+
+```python
+try:
+  import external_dependency_python_N
+except ImportError:
+  _logger.info('Can not `import external_dependency_python_N`.')
+```
+
 ## Python
 
 ### PEP8 options
@@ -603,6 +642,7 @@ The differences include:
     * Using one file per model
     * Separating data and demo data xml folders
     * Not changing xml_ids while inheriting
+    * Add guideline to use external dependencies
 * [Python](#python)
     * Fuller PEP8 compliance
     * Using relative import for local files

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -248,6 +248,7 @@ If your module use extras dependencies of python or binaries you should add to `
 ```
 
 An entry in `bin` needs to be in `PATH` identify with `which external_dependency_binary_N` command.
+
 An entry in `python` needs to be in `PYTHONPATH` identify with `python -c "import external_dependency_python_N"` command.
 
 #### ImportError

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,8 +226,7 @@ If your module use extras dependencies of python or binaries you should add to `
 
 ```python
 {
-    'name': 'Module of example',
-    'depends': ['base'],
+    'name': 'Example Module',
     ...
     'external_dependencies': {
         'bin': [
@@ -248,6 +247,9 @@ If your module use extras dependencies of python or binaries you should add to `
 }
 ```
 
+An entry in `bin` needs to be in `PATH` identify with `which external_dependency_binary_N` command.
+An entry in `python` needs to be in `PYTHONPATH` identify with `python -c "import external_dependency_python_N"` command.
+
 #### ImportError
 In python files where you use a `import external_dependency_python_N` you will need to add a `try-except` with a info log.
 
@@ -255,7 +257,7 @@ In python files where you use a `import external_dependency_python_N` you will n
 try:
   import external_dependency_python_N
 except ImportError:
-  _logger.info('Can not `import external_dependency_python_N`.')
+  _logger.debug('Can not `import external_dependency_python_N`.')
 ```
 
 #### README


### PR DESCRIPTION
If we use `external_dependencies` we will have validation of installed packages in install module button.
How to work `external_dependencies` (without `static` folder): [here](https://asciinema.org/a/23098)

But if we don't use `try-except` we will have a error if exists `static` folder:
How to work `external_dependencies` (with `static` folder): [here](https://asciinema.org/a/23103)
Then we will need to add a try-except, but this should be a info error because the real error will show when you want to install the module if you don't use this module then you don't have warning or error just info log.