### PR TITLE
Variable name CamelCase potential problem of `redefined` variable.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -323,16 +323,25 @@ class account_invoice(orm.Model):
 ```
 
 #### Variable name :
-* use camelcase for model variable
-* use underscore lowercase notation for common variable.
+* use underscore lowercase notation for common variable (snake_case)
 * since new API works with record or recordset instead of id list, don't suffix
   variable name with `_id` or `_ids` if they do not contain an id or a list of
   ids.
 
 ```python
-ResPartner = self.env['res.partner']
-partners = ResPartner.browse(ids)
-partner_id = partners[0].id
+    ...
+    res_partner = self.env['res.partner']
+    partners = res_partner.browse(ids)
+    partner_id = partners[0].id
+```
+
+* Use underscore uppercase notation for global variables or constants
+```python
+...
+CONSTANT_VAR1 = 'Value'
+...
+class...
+...
 ```
 
 ### Field
@@ -609,6 +618,8 @@ The differences include:
     * More python idioms
     * A way to deal with long comma-separated lines
     * Hints on documentation
+    * Don't use CamelCase for model variable
+    * Use underscore uppercase notation for global variables or constants
 * [Fields](#fields)
     * A hint for function defaults
 * [Tests Section Added](#tests)


### PR DESCRIPTION
I saw in oca guidelines this matter:
******************
#### Variable name :
*  **use camelcase for model variable**
* use underscore lowercase notation for common variable.
* since new API works with record or recordset instead of id list, don't suffix
  variable name with `_id` or `_ids` if they do not contain an id or a list of
  ids.

```python
ResPartner = self.env['res.partner']
partners = ResPartner.browse(ids)
partner_id = partners[0].id
```
******************

I want comment a problem with this:
 1. Use CamelCase in a variable don't is a pep8 standard.
 1. We will have potential problem of redefined variable.
   1. By example:
```python
        class ResPartner(model.Models):
        ...
        ResPartner = self.env['res.partner']
```

Why don't use as pep8 told us: snake_case to variable name?