### PR TITLE
Add module version numbers guideline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,24 @@ section.
   that is already in the plural (i.e. mrp_operations_....).
 * Use the [description template](https://github.com/OCA/maintainer-tools/tree/master/template/module)
 
+### Version numbers
+
+The version number in the module manifest should be the Odoo major
+version (e.g. `8.0`) followed by the module `x.y` version numbers.
+For example: `8.0.1.0` is expected for the first release of an 8.0
+module.
+
+The `x.y` version numbers follow the semantics `breaking.feature`:
+  * `x` increments when changes can break modules extending on it
+  * `y` increments when non-breaking new features are added
+
+If applicable, breaking changes are expected to include instruction
+or scripts to perform migration on current installations.
+
+Unless fitting in the above criteria, bugfixes are not required
+to increment module version numbers.
+
+
 ### Directories
 
 A module is organised in a few directory:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,19 +20,22 @@ section.
 ### Version numbers
 
 The version number in the module manifest should be the Odoo major
-version (e.g. `8.0`) followed by the module `x.y` version numbers.
-For example: `8.0.1.0` is expected for the first release of an 8.0
+version (e.g. `8.0`) followed by the module `x.y.z` version numbers.
+For example: `8.0.1.0.0` is expected for the first release of an 8.0
 module.
 
-The `x.y` version numbers follow the semantics `breaking.feature`:
-  * `x` increments when changes can break modules extending on it
-  * `y` increments when non-breaking new features are added
+The `x.y.z` version numbers follow the semantics `breaking.feature.fix`:
 
-If applicable, breaking changes are expected to include instruction
+  * `x` increments when the data model or the views had significant
+    changes. Data migration might be needed, or depending modules might
+    be affected.
+  * `y` increments when non-breaking new features are added. A module
+    upgrade will probably be needed.
+  * `z` increments when bugfixes were made. Usually a server restart
+    is needed for the fixes to be made available.
+
+If applicable, breaking changes are expected to include instructions
 or scripts to perform migration on current installations.
-
-Unless fitting in the above criteria, bugfixes are not required
-to increment module version numbers.
 
 
 ### Directories


### PR DESCRIPTION
Reopening #90.

Currently there is consensus in the Odoo version prefix, eg `8.0`
Regarding the next version number we had several views. Current proposal text is for semantic `breaking.feature.fix`.