### PR TITLE
README template: make the module title a real title

### DIFF
--- a/template/module/README.rst
+++ b/template/module/README.rst
@@ -1,6 +1,7 @@
 .. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
     :alt: License: AGPL-3
 
+==============
 {module_title}
 ==============
 


### PR DESCRIPTION
As discussed [here](https://github.com/OCA/e-commerce/pull/50#discussion-diff-37542460)

By using a different decoration style from the other sections, the module title gets a more important heading than the other sections when rendered, as it should be.

Reference: http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#sections
> Rather than imposing a fixed number and order of section title adornment styles, the order enforced will be the order as encountered. The first style encountered will be an outermost title (like HTML H1), the second style will be a subtitle, the third will be a subsubtitle, and so on.

For example if converting to latex with `rst2latex`, with this correction the module title is put inside the `\title` element and the other sections in a `\section` element.
Without this correction everything would be put in a `\section` element (and only because there can't be multiple `\title` elements!) or, in HTML, all will be put inside `h1` elements.

The difference is noticeable also in the default GitHub rendering of the READMEs!