### PR TITLE
[IMP] complete coding message

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -368,7 +368,7 @@ except ImportError:
 
 ### Idioms
 
-* Each python file should have ``# -*- coding: utf-8 -*-`` as first line
+* Each python file should have ``# coding: utf-8`` or ``# -*- coding: utf-8 -*-`` as first line
 * Prefer `%` over `.format()`, prefer `%(varname)` instead of positional.
   This is better for translation and clarity.
 * Always favor **Readability** over **conciseness** or using the language

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -724,7 +724,9 @@ The differences include:
     * Avoid use current module in xml_id
     * Use explicit `user_id` field for records of model `ir.filters`
 * [Python](#python)
+    Use Python standards
     * Fuller PEP8 compliance
+    * use ``# coding: utf-8`` or ``# -*- coding: utf-8 -*-`` in first line
     * Using relative import for local files
     * More python idioms
     * A way to deal with long comma-separated lines


### PR DESCRIPTION
As far I know, OCA decided to stick to python standard (a real good thing).
In coding matter, we should allowed to add this string too.
In the official doc https://www.python.org/dev/peps/pep-0263 § Defining the Encoding, 
it's the first example (and the shorter) that we could use.

@moylop260 asked me to make this PR 
https://github.com/OCA/server-tools/pull/171#discussion_r38918913

I know, somebody will tell us: all oca modules use -\*-  ...  -\*-
But last year, classes in OCA were not in camel case and we changed 
to stick standards and get it easier to read.

And to conclude it's good thing for the earth, you save bytes in the cloud :earth_africa: ;-)