### PR TITLE
[ADD] gen_addons_table script

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,3 +27,4 @@ console_scripts =
     oca-sync-users = tools.oca_sync_users:main
     oca-autopep8 = tools.autopep8_extended:main
     oca-tx-pull = tools.tx_pull:main
+    oca-gen-addons-table = tools.gen_addons_table:main

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_autopep8_extended
+from . import test_gen_addons_table

--- a/tests/test_gen_addons_table.py
+++ b/tests/test_gen_addons_table.py
@@ -1,0 +1,27 @@
+import os
+import subprocess
+import unittest
+
+
+class TestGenAddonsTable(unittest.TestCase):
+
+    def test_1(self):
+        dirname = os.path.dirname(__file__)
+        cwd = os.path.join(dirname, 'test_repo')
+        gen_addons_table = os.path.join(dirname, '..', 'tools',
+                                        'gen_addons_table')
+        readme_filename = os.path.join(dirname, 'test_repo',
+                                       'README.md')
+        readme_before = open(readme_filename).read()
+        readme_expected_filename = os.path.join(dirname, 'test_repo',
+                                                'README.md.expected')
+        readme_expected = open(readme_expected_filename).read()
+        try:
+            res = subprocess.call([gen_addons_table], cwd=cwd)
+            self.assertEquals(res, 0, 'gen_addons_table failed')
+            readme_after = open(readme_filename).read()
+            self.assertEquals(readme_after, readme_expected,
+                              'gen_addons_table did not generate '
+                              'expected result')
+        finally:
+            open(readme_filename, 'w').write(readme_before)

--- a/tests/test_gen_addons_table.py
+++ b/tests/test_gen_addons_table.py
@@ -9,7 +9,7 @@ class TestGenAddonsTable(unittest.TestCase):
         dirname = os.path.dirname(__file__)
         cwd = os.path.join(dirname, 'test_repo')
         gen_addons_table = os.path.join(dirname, '..', 'tools',
-                                        'gen_addons_table')
+                                        'gen_addons_table.py')
         readme_filename = os.path.join(dirname, 'test_repo',
                                        'README.md')
         readme_before = open(readme_filename).read()

--- a/tests/test_repo/README.md
+++ b/tests/test_repo/README.md
@@ -1,0 +1,16 @@
+[![Runbot Status](https://runbot.odoo-community.org/runbot/badge/flat/${REPO_ID}/${BRANCH_NAME}.svg)](https://runbot.odoo-community.org/runbot/repo/github-com-oca-${REPO_NAME}-${REPO_ID})
+[![Build Status](https://travis-ci.org/OCA/${REPO_NAME}.svg?branch=${BRANCH_NAME})](https://travis-ci.org/OCA/${REPO_NAME})
+[![Coverage Status](https://coveralls.io/repos/OCA/${REPO_NAME}/badge.svg?branch=${BRANCH_NAME})](https://coveralls.io/r/OCA/${REPO_NAME}?branch=${BRANCH_NAME})
+[![Code Climate](https://codeclimate.com/github/OCA/${REPO_NAME}/badges/gpa.svg)](https://codeclimate.com/github/OCA/${REPO_NAME})
+
+# ${REPO_NAME_VERBOSE}
+
+${REPO_DESCRIPTION}
+
+[//]: # (addons)
+This part will be replaced when running the gen_addon_tables script.
+[//]: # (end addons)
+
+Translation Status
+------------------
+[![Transifex Status](https://www.transifex.com/projects/p/${ORG_NAME}-${REPO_NAME}-${BRANCH_NAME_WITH_DASH}/chart/image_png)](https://www.transifex.com/projects/p/${ORG_NAME}-${REPO_NAME}-${BRANCH_NAME_WITH_DASH})

--- a/tests/test_repo/README.md.expected
+++ b/tests/test_repo/README.md.expected
@@ -1,0 +1,27 @@
+[![Runbot Status](https://runbot.odoo-community.org/runbot/badge/flat/${REPO_ID}/${BRANCH_NAME}.svg)](https://runbot.odoo-community.org/runbot/repo/github-com-oca-${REPO_NAME}-${REPO_ID})
+[![Build Status](https://travis-ci.org/OCA/${REPO_NAME}.svg?branch=${BRANCH_NAME})](https://travis-ci.org/OCA/${REPO_NAME})
+[![Coverage Status](https://coveralls.io/repos/OCA/${REPO_NAME}/badge.svg?branch=${BRANCH_NAME})](https://coveralls.io/r/OCA/${REPO_NAME}?branch=${BRANCH_NAME})
+[![Code Climate](https://codeclimate.com/github/OCA/${REPO_NAME}/badges/gpa.svg)](https://codeclimate.com/github/OCA/${REPO_NAME})
+
+# ${REPO_NAME_VERBOSE}
+
+${REPO_DESCRIPTION}
+
+[//]: # (addons)
+Available addons
+----------------
+addon | version | summary
+--- | --- | ---
+[module1](module1/) | 8.0.1.0.0 | Module 1 summary
+
+Unported addons
+---------------
+addon | version | summary
+--- | --- | ---
+[module3](__unported__/module3/) | 8.0.1.0.0 (unported) | Module 3 summary
+[module2](module2/) | 8.0.1.0.0 (unported) | Module 2 summary
+[//]: # (end addons)
+
+Translation Status
+------------------
+[![Transifex Status](https://www.transifex.com/projects/p/${ORG_NAME}-${REPO_NAME}-${BRANCH_NAME_WITH_DASH}/chart/image_png)](https://www.transifex.com/projects/p/${ORG_NAME}-${REPO_NAME}-${BRANCH_NAME_WITH_DASH})

--- a/tests/test_repo/README.md.expected
+++ b/tests/test_repo/README.md.expected
@@ -20,6 +20,7 @@ addon | version | summary
 --- | --- | ---
 [module3](__unported__/module3/) | 8.0.1.0.0 (unported) | Module 3 summary
 [module2](module2/) | 8.0.1.0.0 (unported) | Module 2 summary
+
 [//]: # (end addons)
 
 Translation Status

--- a/tests/test_repo/__unported__/module3/README.rst
+++ b/tests/test_repo/__unported__/module3/README.rst
@@ -1,0 +1,80 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==============
+{module_title}
+==============
+
+This module was written to extend the functionality of ... to support ...
+and allow you to ...
+
+Installation
+============
+
+To install this module, you need to:
+
+* do this ...
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+* go to ...
+
+Usage
+=====
+
+To use this module, you need to:
+
+* go to ...
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/{repo_id}/{branch}
+
+.. repo_id is available in https://github.com/OCA/maintainer-tools/blob/master/tools/repos_with_ids.txt
+.. branch is "8.0" for example
+
+For further information, please visit:
+
+* https://www.odoo.com/forum/help-1
+
+Known issues / Roadmap
+======================
+
+* ...
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/{project_repo}/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/{project_repo}/issues/new?body=module:%20{module_name}%0Aversion:%20{version}%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Firstname Lastname <email.address@example.org>
+* Second Person <second.person@example.org>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/tests/test_repo/__unported__/module3/__init__.py
+++ b/tests/test_repo/__unported__/module3/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# © <YEAR(S)> <AUTHOR(S)>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).

--- a/tests/test_repo/__unported__/module3/__openerp__.py
+++ b/tests/test_repo/__unported__/module3/__openerp__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# © <YEAR(S)> <AUTHOR(S)>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Module 3",
+    "summary": "Module 3 summary",
+    "version": "8.0.1.0.0",
+    "category": "Uncategorized",
+    "website": "https://odoo-community.org/",
+    "author": "<AUTHOR(S)>, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": False,
+    "external_dependencies": {
+        "python": [],
+        "bin": [],
+    },
+    "depends": [
+        "base",
+    ],
+    "data": [
+    ],
+    "demo": [
+    ],
+}

--- a/tests/test_repo/module1/README.rst
+++ b/tests/test_repo/module1/README.rst
@@ -1,0 +1,80 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==============
+{module_title}
+==============
+
+This module was written to extend the functionality of ... to support ...
+and allow you to ...
+
+Installation
+============
+
+To install this module, you need to:
+
+* do this ...
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+* go to ...
+
+Usage
+=====
+
+To use this module, you need to:
+
+* go to ...
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/{repo_id}/{branch}
+
+.. repo_id is available in https://github.com/OCA/maintainer-tools/blob/master/tools/repos_with_ids.txt
+.. branch is "8.0" for example
+
+For further information, please visit:
+
+* https://www.odoo.com/forum/help-1
+
+Known issues / Roadmap
+======================
+
+* ...
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/{project_repo}/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/{project_repo}/issues/new?body=module:%20{module_name}%0Aversion:%20{version}%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Firstname Lastname <email.address@example.org>
+* Second Person <second.person@example.org>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/tests/test_repo/module1/__init__.py
+++ b/tests/test_repo/module1/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# © <YEAR(S)> <AUTHOR(S)>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).

--- a/tests/test_repo/module1/__openerp__.py
+++ b/tests/test_repo/module1/__openerp__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# © <YEAR(S)> <AUTHOR(S)>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Module 1",
+    "summary": "Module 1 summary",
+    "version": "8.0.1.0.0",
+    "category": "Uncategorized",
+    "website": "https://odoo-community.org/",
+    "author": "<AUTHOR(S)>, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "external_dependencies": {
+        "python": [],
+        "bin": [],
+    },
+    "depends": [
+        "base",
+    ],
+    "data": [
+    ],
+    "demo": [
+    ],
+}

--- a/tests/test_repo/module2/README.rst
+++ b/tests/test_repo/module2/README.rst
@@ -1,0 +1,80 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==============
+{module_title}
+==============
+
+This module was written to extend the functionality of ... to support ...
+and allow you to ...
+
+Installation
+============
+
+To install this module, you need to:
+
+* do this ...
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+* go to ...
+
+Usage
+=====
+
+To use this module, you need to:
+
+* go to ...
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/{repo_id}/{branch}
+
+.. repo_id is available in https://github.com/OCA/maintainer-tools/blob/master/tools/repos_with_ids.txt
+.. branch is "8.0" for example
+
+For further information, please visit:
+
+* https://www.odoo.com/forum/help-1
+
+Known issues / Roadmap
+======================
+
+* ...
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/{project_repo}/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/{project_repo}/issues/new?body=module:%20{module_name}%0Aversion:%20{version}%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Firstname Lastname <email.address@example.org>
+* Second Person <second.person@example.org>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/tests/test_repo/module2/__init__.py
+++ b/tests/test_repo/module2/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# © <YEAR(S)> <AUTHOR(S)>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).

--- a/tests/test_repo/module2/__openerp__.py
+++ b/tests/test_repo/module2/__openerp__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# © <YEAR(S)> <AUTHOR(S)>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Module 2",
+    "summary": "Module 2 summary",
+    "version": "8.0.1.0.0",
+    "category": "Uncategorized",
+    "website": "https://odoo-community.org/",
+    "author": "<AUTHOR(S)>, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": False,
+    "external_dependencies": {
+        "python": [],
+        "bin": [],
+    },
+    "depends": [
+        "base",
+    ],
+    "data": [
+    ],
+    "demo": [
+    ],
+}

--- a/tools/gen_addons_table
+++ b/tools/gen_addons_table
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+#  -*- coding: utf-8 -*-
+"""
+This script replaces markers in the README.md files
+of an OCA repository with the list of addons present
+in the repository. It preserves the marker so it
+can be run again.
+
+The script must be run from the root of the repository,
+where the README.md file can be found.
+
+Markers in README.md must have the form:
+
+[//]: # (addons)
+does not matter, will be replaced by the script
+[//]: # (end addons)
+"""
+
+from __future__ import print_function
+import ast
+import os
+import re
+
+
+MARKERS = r'(\[//\]: # \(addons\))|(\[//\]: # \(end addons\))'
+
+
+class UserError(Exception):
+    def __init__(self, msg):
+        self.msg = msg
+
+
+def sanitize_cell(s):
+    if not s:
+        return ''
+    s = ' '.join(s.split())
+    return s
+
+
+def render_markdown_table(header, rows):
+    table = []
+    rows = [header, ['---'] * len(header)] + rows
+    for row in rows:
+        table.append(' | '.join(row))
+    return '\n'.join(table)
+
+
+def replace_in_readme(readme_path, header, rows_available, rows_unported):
+    readme = open(readme_path).read()
+    parts = re.split(MARKERS, readme, flags=re.MULTILINE)
+    if len(parts) != 7:
+        raise UserError('Addons markers not found or incorrect in %s' %
+                        readme_path)
+    addons = []
+    if rows_available:
+        addons.extend([
+            '\n',
+            'Available addons\n',
+            '----------------\n',
+            render_markdown_table(header, rows_available),
+            '\n'
+        ])
+    if rows_unported:
+        addons.extend([
+            '\n',
+            'Unported addons\n',
+            '---------------\n',
+            render_markdown_table(header, rows_unported),
+            '\n'
+        ])
+    parts[2:5] = addons
+    readme = ''.join(parts)
+    open(readme_path, 'w').write(readme)
+
+
+def gen_addons_table():
+    readme_path = 'README.md'
+    if not os.path.isfile(readme_path):
+        raise UserError('%s not found' % readme_path)
+    # list addons in . and __unported__
+    addon_paths = []  # list of (addon_path, unported)
+    for addon_path in os.listdir('.'):
+        addon_paths.append((addon_path, False))
+    unported_directory = '__unported__'
+    if os.path.isdir(unported_directory):
+        for addon_path in os.listdir(unported_directory):
+            addon_path = os.path.join(unported_directory, addon_path)
+            addon_paths.append((addon_path, True))
+    addon_paths = sorted(addon_paths, lambda x, y: cmp(x[0], y[0]))
+    # load manifests
+    header = ('addon', 'version', 'summary')
+    rows_available = []
+    rows_unported = []
+    for addon_path, unported in addon_paths:
+        manifest_path = os.path.join(addon_path, '__openerp__.py')
+        if os.path.isfile(manifest_path):
+            manifest = ast.literal_eval(open(manifest_path).read())
+            addon_name = os.path.basename(addon_path)
+            link = '[%s](%s/)' % (addon_name, addon_path)
+            version = manifest.get('version') or ''
+            summary = manifest.get('summary') or manifest.get('name')
+            summary = sanitize_cell(summary)
+            installable = manifest.get('installable', True)
+            if unported and installable:
+                raise UserError('%s is in __unported__ but is marked '
+                                'installable.' % addon_path)
+            if installable:
+                rows_available.append((link, version, summary))
+            else:
+                rows_unported.append((link, version + ' (unported)', summary))
+    # replace table in README.md
+    replace_in_readme(readme_path, header, rows_available, rows_unported)
+
+
+if __name__ == '__main__':
+    try:
+        gen_addons_table()
+    except UserError as e:
+        print(e.msg)
+        exit(1)

--- a/tools/gen_addons_table.py
+++ b/tools/gen_addons_table.py
@@ -112,9 +112,12 @@ def gen_addons_table():
     replace_in_readme(readme_path, header, rows_available, rows_unported)
 
 
-if __name__ == '__main__':
+def main():
     try:
         gen_addons_table()
     except UserError as e:
         print(e.msg)
         exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/tools/gen_addons_table.py
+++ b/tools/gen_addons_table.py
@@ -68,6 +68,7 @@ def replace_in_readme(readme_path, header, rows_available, rows_unported):
             render_markdown_table(header, rows_unported),
             '\n'
         ])
+    addons.append('\n')
     parts[2:5] = addons
     readme = ''.join(parts)
     open(readme_path, 'w').write(readme)


### PR DESCRIPTION
A script that replaces a placeholder in the repository-level README.md with two tables showing the available and unported modules along with their version number and a summary (or name if summary is absent). The placeholder is preserved after running the script.

The placeholder in README.md must be like this (```...``` can be anything):
```
[//]: # (addons)
...
[//]: # (end addons)
```

The syntax for markdown comments comes from http://stackoverflow.com/questions/4823468/store-comments-in-markdown-syntax.

Supersedes https://github.com/OCA/maintainer-quality-tools/pull/239, same code, better repo.
