### PR TITLE
Change version to branch

### DIFF
--- a/template/module/README.rst
+++ b/template/module/README.rst
@@ -51,7 +51,7 @@ In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed feedback `here <https://github.com/OCA/
 {project_repo}/issues/new?body=module:%20
 {module_name}%0Aversion:%20
-{version}%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+{branch}%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 
 Credits


### PR DESCRIPTION
I suggest to indicate the branch in feedback url as following, having a version in template says to me (IMHO) that is the module version as pointed out in CONTRIBUTING.md in [L25](https://github.com/OCA/maintainer-tools/blame/master/CONTRIBUTING.md#L25) with semantical way. But in fact is the branch that the module actually is.

**Current template:**
```text
{project_repo}/issues/new?body=module:%20
{module_name}%0Aversion:%20
{version}%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
```

**Proposal template:**
```text
{project_repo}/issues/new?body=module:%20
{module_name}%0Aversion:%20
{branch}%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
```