### PR TITLE
[FIX] typo in oca_projects.py

### DIFF
--- a/tools/oca_projects.py
+++ b/tools/oca_projects.py
@@ -151,7 +151,7 @@ def get_repositories():
     }
     gh = login()
     all_repos = [repo.name for repo in gh.iter_user_repos('OCA')
-                 if repo not in ignored]
+                 if repo.name not in ignored]
     return all_repos
 
 try:


### PR DESCRIPTION
get_repositories() was not filtering out non-addons repositories as intended