### PR TITLE
[FIX] Avoid problems with str vs unicode when formatting

### DIFF
--- a/template/module/exceptions.py
+++ b/template/module/exceptions.py
@@ -2,6 +2,7 @@
 # © <YEAR(S)> <AUTHOR(S)>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from __future__ import unicode_literals
 from openerp import _, exceptions
 
 


### PR DESCRIPTION
When formatting exception messages, and an argument is a unicode with accents, formatting fails. This fixes that by using unicodes by default.