### PR TITLE
[WIP][FIX] gitignore: add rule exception for static/lib/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ docs/_build/
 # Backup files
 *~
 *.swp
+
+# OCA rules
+!static/lib/


### PR DESCRIPTION
Based on OCA/rma#69 it is needed to add an exception rule for `lib/` folder under `static/` following [guidelines](https://github.com/OCA/maintainer-tools/blob/master/CONTRIBUTING.md#directories) to allow keep track external libs added to modules, currently it is required to do a `git add -f lib/SpecialLib.js` to get accomplished file inclusion into the repository.

The following asciinema shows this rule https://asciinema.org/a/2ucpz7oua8i6tuyey1cd2plrl