### PR TITLE
Reduce license headers a bit more.

### DIFF
--- a/template/module/__init__.py
+++ b/template/module/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 # © <YEAR(S)> <AUTHOR(S)>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import models, wizards, controllers, report

--- a/template/module/__openerp__.py
+++ b/template/module/__openerp__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # © <YEAR(S)> <AUTHOR(S)>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Module name",
     "summary": "Module summary",

--- a/template/module/controllers/__init__.py
+++ b/template/module/controllers/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 # © <YEAR(S)> <AUTHOR(S)>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import main

--- a/template/module/controllers/main.py
+++ b/template/module/controllers/main.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # © <YEAR(S)> <AUTHOR(S)>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from openerp import http
 

--- a/template/module/data/model_name_data.xml
+++ b/template/module/data/model_name_data.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- © <YEAR(S)> <AUTHOR(S)>
-     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 
 <openerp>
 <data>

--- a/template/module/demo/model_name_demo.xml
+++ b/template/module/demo/model_name_demo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- © <YEAR(S)> <AUTHOR(S)>
-     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 
 <openerp>
 <data>

--- a/template/module/exceptions.py
+++ b/template/module/exceptions.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # © <YEAR(S)> <AUTHOR(S)>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from openerp import _, exceptions
 

--- a/template/module/migrations/8.0.1.0.0/post-migrate.py
+++ b/template/module/migrations/8.0.1.0.0/post-migrate.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # © <YEAR(S)> <AUTHOR(S)>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 
 def migrate(cr, version):

--- a/template/module/migrations/8.0.1.0.0/pre-migrate.py
+++ b/template/module/migrations/8.0.1.0.0/pre-migrate.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # © <YEAR(S)> <AUTHOR(S)>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 
 def migrate(cr, version):

--- a/template/module/models/__init__.py
+++ b/template/module/models/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 # © <YEAR(S)> <AUTHOR(S)>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import model_name

--- a/template/module/models/model_name.py
+++ b/template/module/models/model_name.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # © <YEAR(S)> <AUTHOR(S)>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from openerp import models
 

--- a/template/module/report/__init__.py
+++ b/template/module/report/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 # © <YEAR(S)> <AUTHOR(S)>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import report_name

--- a/template/module/report/report_name.py
+++ b/template/module/report/report_name.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # © <YEAR(S)> <AUTHOR(S)>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from openerp import api, models
 

--- a/template/module/security/some_model_security.xml
+++ b/template/module/security/some_model_security.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- © <YEAR(S)> <AUTHOR(S)>
-     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 
 <openerp>
 <data>

--- a/template/module/static/src/css/module_name.css
+++ b/template/module/static/src/css/module_name.css
@@ -1,6 +1,5 @@
 /* © <YEAR(S)> <AUTHOR(S)>
- * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
- */
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
 
 .some-class {
     font-size: 12pt;

--- a/template/module/static/src/js/module_name.js
+++ b/template/module/static/src/js/module_name.js
@@ -1,6 +1,5 @@
 /* © <YEAR(S)> <AUTHOR(S)>
- * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
- */
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
 
 "use strict";
 (function ($) {

--- a/template/module/static/src/xml/module_name.xml
+++ b/template/module/static/src/xml/module_name.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- © <YEAR(S)> <AUTHOR(S)>
-     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 
 <template>
     <t t-extend="other.qweb.template">

--- a/template/module/tests/__init__.py
+++ b/template/module/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 # © <YEAR(S)> <AUTHOR(S)>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_something

--- a/template/module/tests/test_something.py
+++ b/template/module/tests/test_something.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # © <YEAR(S)> <AUTHOR(S)>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from openerp.tests.common import TransactionCase
 

--- a/template/module/views/assets.xml
+++ b/template/module/views/assets.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- © <YEAR(S)> <AUTHOR(S)>
-     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 
 <openerp>
 <data>

--- a/template/module/views/model_name_view.xml
+++ b/template/module/views/model_name_view.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- © <YEAR(S)> <AUTHOR(S)>
-     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 
 <openerp>
 <data>

--- a/template/module/views/report_name.xml
+++ b/template/module/views/report_name.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- © <YEAR(S)> <AUTHOR(S)>
-     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 
 <openerp>
 <data>

--- a/template/module/wizards/__init__.py
+++ b/template/module/wizards/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 # © <YEAR(S)> <AUTHOR(S)>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import wizard_model

--- a/template/module/wizards/wizard_model.py
+++ b/template/module/wizards/wizard_model.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # © <YEAR(S)> <AUTHOR(S)>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from openerp import api, models
 

--- a/template/module/wizards/wizard_model_view.xml
+++ b/template/module/wizards/wizard_model_view.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- © <YEAR(S)> <AUTHOR(S)>
-     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 
 <openerp>
 <data>


### PR DESCRIPTION
In JS and CSS files, we save a line, in all others we save 5 chars.