### PR TITLE
[FIX] `use strict` inside functions.

### DIFF
--- a/template/module/static/src/js/module_name.js
+++ b/template/module/static/src/js/module_name.js
@@ -1,7 +1,7 @@
 /* Copyright <YEAR(S)> <AUTHOR(S)>
  * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
 
-"use strict";
 (function ($) {
+    "use strict";
     // Script that will be loaded when document is ready
 })(jQuery);

--- a/template/module/static/src/js/module_name.tour.js
+++ b/template/module/static/src/js/module_name.tour.js
@@ -1,8 +1,8 @@
 /* Copyright <YEAR(S)> <AUTHOR(S)>
  * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
 
-"use strict";
 odoo.define("module_name.tour", function (require) {
+"use strict";
 
 // Dependencies here by alphabetic order. Template only for Odoo 9+.
 var Core = require("web.core");


### PR DESCRIPTION
### Milestone (Odoo version)
- any

### Module(s)
- module template

### Fixes / new features

Odoo automatically minifies and concatenates all scripts. Given [`use strict` may only be used at the beginning of a script or of a function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode), minified version would not be strict unless it is declared inside the function. Even worse, a strict script loaded as the 1st one could affect other non-strict ones loaded later.

So, in short, this should be considered a guideline.

@Tecnativa