### PR TITLE
[REF] CONTRIBUTING: Use replace is not recommended

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -306,20 +306,20 @@ same name.
 
 Use of `<... position="replace">` is not recommended because
 could show the error `Element ... cannot be located in parent view`
-from other views inheriting with this field.
+from other inherited views with this field.
 
-if you need to use this option, must have an explicit comment
-explaining why they are absolutely necessary and use a
-high value of priority to avoid the error.
+If you need to use this option, it must have an explicit comment
+explaining why it is absolutely necessary and also use a
+high value in its `priority` (greater than 100 is recommended) to avoid the error.
 
 
 ```xml
 <record id="view_id" model="ir.ui.view">
     <field name="name">view.name</field>
     <field name="model">object_name</field>
-    <field name="priority">110</field> <!--Priority greather than 100-->
+    <field name="priority">110</field> <!--Priority greater than 100-->
     <field name="arch" type="xml">
-        <!--Necessary because...-->
+        <!-- It is necessary because...-->
         <xpath expr="//field[@name='my_field_1']" position="replace"/>
     </field>
 </record>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,7 +191,6 @@ When declaring a record in XML:
 * For field declarations, the `name` attribute is first. Then place the `value`
   either in the `field` tag, either in the `eval` attribute, and finally other
   attributes (widget, options, ...) ordered by importance.
-
 * Try to group the records by model. In case of dependencies between
   action/menu/views, the convention may not be applicable.
 * Use naming convention defined at the next point
@@ -303,6 +302,29 @@ same name.
     ...
 </record>
 ```
+
+
+Use of `<... position="replace">` is not recommended because
+could show the error `Element ... cannot be located in parent view`
+from other views inheriting with this field.
+
+if you need use this option, must have an explicit comment
+explaining why they are absolutely necessary and use a
+high value of priority to avoid the error.
+
+
+```xml
+<record id="view_id" model="ir.ui.view">
+    <field name="name">view.name</field>
+    <field name="model">object_name</field>
+    <field name="priority">110</field> <!--Priority greather than 100-->
+    <field name="arch" type="xml">
+        <!--Necessary because...-->
+        <xpath expr="//field[@name='my_field_1']" position="replace"/>
+    </field>
+</record>
+```
+
 
 ### External dependencies
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -308,7 +308,7 @@ Use of `<... position="replace">` is not recommended because
 could show the error `Element ... cannot be located in parent view`
 from other views inheriting with this field.
 
-if you need use this option, must have an explicit comment
+if you need to use this option, must have an explicit comment
 explaining why they are absolutely necessary and use a
 high value of priority to avoid the error.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -325,6 +325,8 @@ high value of priority to avoid the error.
 </record>
 ```
 
+Also, we can hide an element from the view using `invisible="1"`.
+
 
 ### External dependencies
 


### PR DESCRIPTION
**New guideline to avoid use `position=replace`**

Use of `<... position="replace">` is not recommended because
could show the error `Element ... cannot be located in parent view`
from other views inheriting with this field.

if you need use this option, must have an explicit comment
explaining why they are absolutely necessary and use a
high value of priority to avoid the error.


```xml
<record id="view_id" model="ir.ui.view">
    <field name="name">view.name</field>
    <field name="model">object_name</field>
    <field name="priority">110</field> <!--Priority greather than 100-->
    <field name="arch" type="xml">
        <!--Necessary because...-->
        <xpath expr="//field[@name='my_field_1']" position="replace"/>
    </field>
</record>
```