### PR TITLE
[FIX] flake8 runtime PicklingError: Can't pickle <type 'function'>: attribute lookup __builtin__.function failed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
     - "2.7"
 
 install:
-    - pip install coveralls flake8
+    - pip install coveralls flake8==2.6.2
     - pip install -r requirements.txt
 
 script:


### PR DESCRIPTION
Fix current build stable travis error of flake8 v3.0.2
<img width="879" alt="screen shot 2016-07-29 at 9 27 07 pm" src="https://cloud.githubusercontent.com/assets/6644187/17267624/8582df84-55d3-11e6-9911-92cb66932bea.png">

Freezing v2.6.2 working fine!
<img width="856" alt="screen shot 2016-07-29 at 9 29 05 pm" src="https://cloud.githubusercontent.com/assets/6644187/17267623/856b2e20-55d3-11e6-9c88-4afce487c54e.png">

Issue: https://gitlab.com/pycqa/flake8/issues/201