### PR TITLE
[ADD] contributing: Add note about avoiding api.v7

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -485,6 +485,8 @@ except ImportError:
 * Use English variable names and write comments in English. Strings which need
   to be displayed in other languages should be translated using the translation
   system
+* Avoid use of ``api.v7`` decorator in new code, unless there is already an API
+  fragmentation in parent methods.
 
 ### Symbols
 


### PR DESCRIPTION
### Milestone (Odoo version)
- 
v9

### Module(s)
- 
Contributing.mg

### Fixes / new features
- 
This adds a note about avoiding api.v7 except in certain scenarios. Wasn't sure where else it fit, so I put it in idioms.

Admittedly I could be completely off-base here, but this seems like a wise recommendation?