### PR TITLE
Enable test tours only in demo instances.

### DIFF
--- a/template/module/__openerp__.py
+++ b/template/module/__openerp__.py
@@ -31,6 +31,7 @@
         "wizards/wizard_model_view.xml",
     ],
     "demo": [
+        "demo/assets.xml",
         "demo/res_partner_demo.xml",
     ],
     "qweb": [

--- a/template/module/demo/assets.xml
+++ b/template/module/demo/assets.xml
@@ -2,15 +2,13 @@
 <!-- Copyright <YEAR(S)> <AUTHOR(S)>
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 
-<openerp>
-<data>
+<odoo>
 
-<template id="assets_frontend_demo" inherit_id="website.assets_frontend">
-    <xpath expr=".">
-        <script type="text/javascript"
-                src="/module/static/src/js/module_name.tour.js"/>
-    </xpath>
-</template>
+    <template id="assets_frontend_demo" inherit_id="website.assets_frontend">
+        <xpath expr=".">
+            <script type="text/javascript"
+                    src="/module/static/src/js/web_module_name.tour.js"/>
+        </xpath>
+    </template>
 
-</data>
-</openerp>
+</odoo>

--- a/template/module/demo/assets.xml
+++ b/template/module/demo/assets.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright <YEAR(S)> <AUTHOR(S)>
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<openerp>
+<data>
+
+<template id="assets_frontend_demo" inherit_id="website.assets_frontend">
+    <xpath expr=".">
+        <script type="text/javascript"
+                src="/module/static/src/js/module_name.tour.js"/>
+    </xpath>
+</template>
+
+</data>
+</openerp>

--- a/template/module/templates/assets.xml
+++ b/template/module/templates/assets.xml
@@ -34,6 +34,7 @@
 
 <template id="assets_editor" inherit_id="website.assets_editor">
     <xpath expr=".">
+        <!-- If tour is only for testing, better add it in demo/assets.xml -->
         <script type="text/javascript"
                 src="/module/static/src/js/module_name.tour.js"/>
     </xpath>


### PR DESCRIPTION
Usually tests depend on demo data, and they are enabled only in development
environments. By enabling the asset in demo data, you remove them from
production instances and thus increase their performance and security, losing
no features.

This follows what was discussed in https://github.com/OCA/web/pull/402#discussion-diff-74550578.

@Tecnativa @lasley 
