### PR TITLE
[FIX] test_something: Fix phantom string for backend

### DIFF
--- a/template/module/tests/test_something.py
+++ b/template/module/tests/test_something.py
@@ -31,7 +31,7 @@ class SomethingCase(TransactionCase):
 class UICase(HttpCase):
     def test_ui_web(self):
         """Test backend tests."""
-        self.phantom_js("/web/tests?mod=module_name", "", login="admin")
+        self.phantom_js("/web/tests?module=module_name", "", login="admin")
 
     def test_ui_website(self):
         """Test frontend tour."""


### PR DESCRIPTION
### Milestone (Odoo version)
- 9.0

### Module(s)
- Http test case for backend

### Fixes / new features

* `module` is the argument to define a module to test in backend, not `mod` in v9 - not sure about other versions