### PR TITLE
[REF] template: Consider 'examples' folder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,8 @@ A module is organized in a few directories:
   `lib/`, ...
 * `views/`: contains the views and templates, and QWeb report print templates
 * `wizards/`: wizard model and views
+* `examples/`: external files
+
 
 ### File naming
 
@@ -221,6 +223,8 @@ addons/<my_module_name>/
     |-- __init__.py
     |-- <wizard_model>.py
     `-- <wizard_model>.xml
+|-- examples/
+|   |-- my_example.csv
 ```
 
 Filenames should use only `[a-z0-9_]`

--- a/template/module/examples/README.rst
+++ b/template/module/examples/README.rst
@@ -1,0 +1,1 @@
+Add external files here, files are not used directly by module.


### PR DESCRIPTION
Many times we need add `examples` files.
- They are used like as reference or they are used to process out of manifest file.

A example is the following file:
 - https://github.com/OCA/l10n-switzerland/blob/8.0/l10n_ch_account_statement_base_import/data/UBS_export.csv

Inspired by https://github.com/OCA/pylint-odoo/issues/47#issue-164800453