### PR TITLE
[REF] template: Add full compatibility to show image from README.rst file

### DIFF
--- a/template/module/README.rst
+++ b/template/module/README.rst
@@ -14,16 +14,16 @@ Installation
 
 To install this module, you need to:
 
-#  Do this ...
+#. Do this ...
 
 Configuration
 =============
 
 To configure this module, you need to:
 
-#  Go to ...
+#. Go to ...
 
-.. figure:: ../module_name/path/to/local/image.png
+.. figure:: ../module/path/to/local/image.png
    :alt: alternative description
    :width: 600 px
 
@@ -32,7 +32,7 @@ Usage
 
 To use this module, you need to:
 
-#  Go to ...
+#. Go to ...
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot

--- a/template/module/README.rst
+++ b/template/module/README.rst
@@ -14,16 +14,16 @@ Installation
 
 To install this module, you need to:
 
-#. Do this ...
+#  Do this ...
 
 Configuration
 =============
 
 To configure this module, you need to:
 
-#. Go to ...
+#  Go to ...
 
-.. figure:: path/to/local/image.png
+.. figure:: ../module_name/path/to/local/image.png
    :alt: alternative description
    :width: 600 px
 
@@ -32,7 +32,7 @@ Usage
 
 To use this module, you need to:
 
-#. Go to ...
+#  Go to ...
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot


### PR DESCRIPTION
We had a circular problem seeing the image from README.rst file in GitHub, apps.odoo.com or Odoo.
Using the path `../{module_name}/{local_image_path}.{ext}` is compatible in all cases.

You could follow the thread here: https://github.com/OCA/business-requirement/pull/18#issuecomment-246665302
