### PR TITLE
Recommend to avoid superfluous massive code changes on backports.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,8 +113,6 @@ A module is organized in a few directories:
   `lib/`, ...
 * `views/`: contains the views and templates, and QWeb report print templates
 * `wizards/`: wizard model and views
-* `examples/`: external files
-
 
 ### File naming
 
@@ -223,8 +221,6 @@ addons/<my_module_name>/
     |-- __init__.py
     |-- <wizard_model>.py
     `-- <wizard_model>.xml
-|-- examples/
-|   |-- my_example.csv
 ```
 
 Filenames should use only `[a-z0-9_]`
@@ -1032,8 +1028,11 @@ must respect a few rules:
 
  * You need to keep the license of the module coded by Odoo SA
  * You need to add the OCA as author (and Odoo SA of course)
- * You need to make the module "OCA compatible" : PEP8, OCA convention and so
-   on so it won't break our CI like runbot, Travis and so.
+ * If the code does not fit with our linters, you have to disable them, so
+   further backport updates become easier, and we can stick the code as close
+   as possible to upstream's.
+   * Add on top of Python files: `# flake8: noqa`
+   * Add on top of ECMAScript files: `// jshint ignore: start`
  * You need to add a disclaimer in the Readme with the following text:
 ```
 **This module is a backport from Odoo SA and as such, it is not included in the OCA CLA. That means we do not have a copy of the copyright on it like all other OCA modules.**


### PR DESCRIPTION
I know this proposal may seem a bit controversial, but let me expose the facts before.

Recently I had to make some backports from master. As you know, master evolves very fast. I consider a good guideline on backports to try to stick as close as possible to upstream updates, because if you fix something in the backport, you will have the bug again when you upgrade, so it's better to either fix in both places or fix upstream and then update the backport.

Also, not so recently, we did some backports from v9 to v8, and then, since that code was now OCA (and beautified), the v8 version evolved by itself. When forward-migrating dependent modules from v8 to v9, we found that the improvements were not there, and thus the migration became much painful.

Updating a backport is a very complex task, mostly when we have to keep the git history. You have to deal with git tree-filters, which create duplicate commits, then you have to discard some, get others, rebases, cherry-picks, etc. And date filters don't help because git branches sometimes merge older commits on top of newer ones, that you would lose. Really not easy at all.

And then we have another extra problem: _linters_. Here is where the interesting part comes.

If you want to make a backported addon PEP-8 and ESLint compatible, **you end up generating a diff for almost every line of code**, mostly having in mind Odoo SA does not take care about beautifying their code at all.

So, when you update a backport from upstream, and you finished dealing with all the git complexities, then comes the merge time, and **you have to review almost every single line of code**. That very step can take up to 4 hours (that was my experience last time).

As a human being, when you are reviewing diffs for 4 hours, and most of them are whitespace diffs, it is very easy to miss a real bug fix among them, and then all the backport updating process loses its sense. Also, this question comes to you mind: this addon is going to last in OCA for only 1 version of Odoo... Then **why such an immense effort for such a short-living addon?**

Lowering the entry and update barriers for backports would help us to have more of them, and keep them updated more often.

So, having all of this in mind, my proposal is that we simply disable linters on backports. That would mean a maximum diff of 1 LOC per file, which would get automatically merged/rebased by git, and all other diffs would be _real_ diffs: adaptations to the older version (that are always needed, of course).

I know backported code would be uglier, and I personally hate that kind of code, but that's IMHO an acceptable short-lived problem that we can live with, compared with the problems that beautifying it arise.

Thanks for the reading.
@Tecnativa
