### PR TITLE
Changes in order to push 10.0 branches to OCA projects

### DIFF
--- a/tools/gen_addons_table.py
+++ b/tools/gen_addons_table.py
@@ -23,6 +23,7 @@ import re
 
 
 MARKERS = r'(\[//\]: # \(addons\))|(\[//\]: # \(end addons\))'
+MANIFESTS = ('__openerp__.py', '__manifest__.py')
 
 
 class UserError(Exception):
@@ -93,8 +94,12 @@ def gen_addons_table():
     rows_available = []
     rows_unported = []
     for addon_path, unported in addon_paths:
-        manifest_path = os.path.join(addon_path, '__openerp__.py')
-        if os.path.isfile(manifest_path):
+        for manifest_file in MANIFESTS:
+            manifest_path = os.path.join(addon_path, manifest_file)
+            has_manifest = os.path.isfile(manifest_path)
+            if has_manifest:
+                break
+        if has_manifest:
             manifest = ast.literal_eval(open(manifest_path).read())
             addon_name = os.path.basename(addon_path)
             link = '[%s](%s/)' % (addon_name, addon_path)


### PR DESCRIPTION
[RFR] Check \_\_manifest\_\_.py when generating addons tables
and migrating branches
[IMP] Rename manifest to \_\_manifest\_\_.py for 10.0 branches
[FIX] Fetch the tree of the target branch, not of the project main branch
[IMP] Fix missing comma when adding dictionary entry
[IMP] Sort modules by name on the migration issue
[ADD] Delete setup addon directories on branch migration
