### PR TITLE
Allow to split main.py in severeal files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,8 @@ For model named `<main_model>` the following files may be created:
 * `templates/<main_model>.xml`
 * `views/<main_model>.xml`
 
-For `controller`, the only file should be named `main.py`.
+For `controller`, if there is only file should be named `main.py`. If there
+are several controller methods you can split them in several files.
 
 For `static files`, the name pattern is `<module_name>.ext` (i.e.
 `static/js/im_chat.js`, `static/css/im_chat.css`, `static/xml/im_chat.xml`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,8 +132,9 @@ For model named `<main_model>` the following files may be created:
 * `templates/<main_model>.xml`
 * `views/<main_model>.xml`
 
-For `controller`, if there is only file should be named `main.py`. If there
-are several controller methods you can split them in several files.
+For `controller`, if there is only one file it should be named `main.py`.
+If there are several controller classes or functions you can split them into
+several files.
 
 For `static files`, the name pattern is `<module_name>.ext` (i.e.
 `static/js/im_chat.js`, `static/css/im_chat.css`, `static/xml/im_chat.xml`,


### PR DESCRIPTION
@simahawk and me purpose to allow spliting controllers/main.py in several files when there are many controller methods or when big ones. And this case can be often in website modules.

We've discussed this in OCA Sprint in Brussels. Now this is our proposal and maybe @lasley, @pedrobaeza, @dreispt and @gurneyalex have something to say about this.
