### PR TITLE
[FIX] properly handle unicode in oca-gen-addons-table

### DIFF
--- a/tools/gen_addons_table.py
+++ b/tools/gen_addons_table.py
@@ -71,6 +71,7 @@ def replace_in_readme(readme_path, header, rows_available, rows_unported):
         ])
     addons.append('\n')
     parts[2:5] = addons
+    parts = [p.encode('utf-8') if isinstance(p, unicode) else p for p in parts]
     readme = ''.join(parts)
     open(readme_path, 'w').write(readme)
 


### PR DESCRIPTION
When addon descriptions contain unicode characters oca-gen-addons-table would fail.