### PR TITLE
[REF] CONTRIBUTING: Grouping external dependencies exception

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -420,14 +420,17 @@ An entry in `python` needs to be in `PYTHONPATH`, check by running
 `python -c "import external_dependency_python_N"`.
 
 #### ImportError
-In python files where you use `import external_dependency_python_N` you will
+In python files where you use external dependencies you will
 need to add `try-except` with a debug log.
 
 ```python
 try:
-  import external_dependency_python_N
-except ImportError:
-  _logger.debug('Cannot `import external_dependency_python_N`.')
+    import external_dependency_python_N
+    import external_dependency_python_M
+    EXTERNAL_DEPENDENCY_BINARY_N_PATH = tools.find_in_path('external_dependency_binary_N')
+    EXTERNAL_DEPENDENCY_BINARY_M_PATH = tools.find_in_path('external_dependency_binary_M')
+except (ImportError, IOError) as err:
+    _logger.debug(err)
 ```
 This rule doesn't apply to the test files since these files are loaded only when
 running tests and in such a case your module and their external dependencies are installed.


### PR DESCRIPTION
Currently if we have many external dependencies we are using:

```python
try:
     import M2Crypto
except ImportError:
    _logger.debug('Can not import M2Crypto.')
try:
     from OpenSSL import crypto
except ImportError:
    _logger.debug('Can not import OpenSSL.')
```

But we could use a reduced way:
```python
try:
     import M2Crypto
     from OpenSSL import crypto
except ImportError as err:
    _logger.debug(err)
```

Currently we have a logger debug just of external dependencies of python libraries but we don't have a logger debug for external dependencies of binaries, using the same reduced way:

```python
try:
     import M2Crypto
     from OpenSSL import crypto
     DIFF3_BIN = tools.find_in_path('diff3')
except (ImportError, IOError) as err:
    _logger.debug(err)
```