### PR TITLE
[FIX] make oca-gen-all-addons-table more resilient to git config changes

### DIFF
--- a/tools/gen_all_addons_tables.py
+++ b/tools/gen_all_addons_tables.py
@@ -62,7 +62,7 @@ def main():
                           '-m', '[UPD] addons table in README.md',
                           'README.md'],
                          cwd=d)
-                    call(['git', 'push', 'origin'], cwd=d)
+                    call(['git', 'push', 'origin', branch], cwd=d)
             except NonFatalError:
                 logging.exception("Error in %s", d, exc_info=True)
 


### PR DESCRIPTION
The default git config was changed on the gitbot server which caused oca-gen-addons-table to fail since a few days. This should fix by being more explicit in the git push command. 