### PR TITLE
[FIX] maintainer-tools: Fix up in requirements bzr version 2.6 replaced for 2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 ERPpeek==1.6.1
 PyYAML==3.11
 argparse==1.2.1
-bzr==2.6.0
+bzr==2.7.0
 github3.py==0.9.4
 requests==2.3.0
 uritemplate.py==0.3.0


### PR DESCRIPTION
### Milestone (Odoo version)
- All

### Module(s)
- All

### Fixes / new features
- [FIX] Error in requirements.txt with version bzr-2.6.0

```bash
Collecting bzr==2.6.0 (from -r requirements.txt (line 4))
  Using cached bzr-2.6.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-OeOdUi/bzr/setup.py", line 205, in <module>
        pyrex_version_info = tuple(map(int, pyrex_version.rstrip("+").split('.')))
    ValueError: invalid literal for int() with base 10: '1post0'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-OeOdUi/bzr/
```
