### PR TITLE
remove copyright from __init__.py

### DIFF
--- a/template/module/__init__.py
+++ b/template/module/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# Copyright <YEAR(S)> <AUTHOR(S)>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import models

--- a/template/module/controllers/__init__.py
+++ b/template/module/controllers/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# Copyright <YEAR(S)> <AUTHOR(S)>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import main

--- a/template/module/models/__init__.py
+++ b/template/module/models/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# Copyright <YEAR(S)> <AUTHOR(S)>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import model_name

--- a/template/module/report/__init__.py
+++ b/template/module/report/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# Copyright <YEAR(S)> <AUTHOR(S)>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import report_name

--- a/template/module/tests/__init__.py
+++ b/template/module/tests/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# Copyright <YEAR(S)> <AUTHOR(S)>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_something

--- a/template/module/wizards/__init__.py
+++ b/template/module/wizards/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# Copyright <YEAR(S)> <AUTHOR(S)>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import wizard_model


### PR DESCRIPTION
### Milestone (Odoo version)
- All

### Module(s)
- All

### Fixes / new features
- Do we want to keep copyright into '__init__.py' files? Depending on reviewers, you can be asked to remove/put copyright from 'init' files. A good point that goes in this direction is that it doesn't contains code. 
