### PR TITLE
addons tables: cope with slight change in github markdown rendering

### DIFF
--- a/tests/test_repo/README.md.expected
+++ b/tests/test_repo/README.md.expected
@@ -8,11 +8,13 @@
 ${REPO_DESCRIPTION}
 
 [//]: # (addons)
+
 Available addons
 ----------------
 addon | version | summary
 --- | --- | ---
 [module1](module1/) | 8.0.1.0.0 | Module 1 summary
+
 
 Unported addons
 ---------------

--- a/tools/gen_addons_table.py
+++ b/tools/gen_addons_table.py
@@ -56,6 +56,7 @@ def replace_in_readme(readme_path, header, rows_available, rows_unported):
     if rows_available:
         addons.extend([
             '\n',
+            '\n',
             'Available addons\n',
             '----------------\n',
             render_markdown_table(header, rows_available),
@@ -63,6 +64,7 @@ def replace_in_readme(readme_path, header, rows_available, rows_unported):
         ])
     if rows_unported:
         addons.extend([
+            '\n',
             '\n',
             'Unported addons\n',
             '---------------\n',


### PR DESCRIPTION
To avoid this:

![image](https://cloud.githubusercontent.com/assets/692075/24306968/b934d102-10c2-11e7-8e9a-5ce4c24e5586.png)
