### PR TITLE
add trove classifiers for OCA meta packages

### DIFF
--- a/tools/bdist_all_wheels.py
+++ b/tools/bdist_all_wheels.py
@@ -35,6 +35,10 @@ setuptools.setup(
    description="Meta package for OCA {repo} Odoo addons",
    version="{branch}.{date}",
    install_requires={install_requires},
+   classifiers=[
+        'Programming Language :: Python :: 2.7',
+        'Framework :: Odoo',
+   ]
 )
 """
 


### PR DESCRIPTION
classifiers for regular (one addon) packages are added by setuptools-odoo