### PR TITLE
[ADD] Demo record XML ID rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ section.
       * [Format](#format)
       * [Records](#records)
       * [Naming xml_id](#naming-xml_id)
+        * [Data Records](#data-records)
         * [Security, View and Action](#security-view-and-action)
         * [Inherited XML](#inherited-xml)
         * [Demo Records](#demo-records)
@@ -292,9 +293,22 @@ More info [here](https://github.com/odoo/odoo/pull/8218)
 
 ### Naming xml_id
 
+#### Data Records
+
+Use the followng pattern, where `<model_name>` is the name of the model that 
+the record is an instance of: `<model_name>_<record_name>`
+
+```xml
+<record id="res_users_important_person" model="res.users">
+    ...
+</record>
+```
+
 #### Security, View and Action
 
-Use the following pattern:
+Use the following patterns, where `<model_name>` is the name of the model that 
+the menu, view, etc. belongs to (e.g. for a `res.users` form view, the name 
+would be `res_users_view_form`):
 
 * For a menu: `<model_name>_menu`
 * For a view: `<model_name>_view_<view_type>`, where `view_type` is kanban,
@@ -397,7 +411,7 @@ distinguished from regular records, which otherwise requires examining the
 source or reinstalling the module with demo data disabled.
 
 ```xml
-<record id="not_a_real_user_demo" model="res.users">
+<record id="res_users_not_a_real_user_demo" model="res.users">
     ...
 </record>
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ section.
       * [Naming xml_id](#naming-xml_id)
         * [Security, View and Action](#security-view-and-action)
         * [Inherited XML](#inherited-xml)
+        * [Demo Records](#demo-records)
       * [External dependencies](#external-dependencies)
         * [`__openerp__.py`](#__openerp__py)
         * [ImportError](#importerror)
@@ -389,6 +390,17 @@ high value in its `priority` (greater than 100 is recommended) to avoid the erro
 
 Also, we can hide an element from the view using `invisible="1"`.
 
+#### Demo Records
+
+Suffix all demo record XML IDs with `demo`. This allows them to be easily
+distinguished from regular records, which otherwise requires examining the
+source or reinstalling the module with demo data disabled.
+
+```xml
+<record id="not_a_real_user_demo" model="res.users">
+    ...
+</record>
+```
 
 ### External dependencies
 


### PR DESCRIPTION
* Add rule to OCA guidelines requiring all demo record XML IDs to end in `demo`
* Add rule to OCA guidelines requiring all XML IDs for data records to begin with the record's model name

The first portion was suggested [here](https://github.com/OCA/delivery-carrier/pull/122#discussion_r113841148) by @lasley and seems like a good move since it can be difficult to tell demo records apart from normal ones. The second part was then added based on [a discussion in this PR](https://github.com/OCA/maintainer-tools/pull/272#pullrequestreview-37844704).
