### PR TITLE
[FIX] XML IDs in module template

### DIFF
--- a/template/module/data/model_name_data.xml
+++ b/template/module/data/model_name_data.xml
@@ -5,7 +5,7 @@
 <openerp>
 <data>
 
-<record id="my_data_record" model="model.name">
+<record id="model_name_my_record" model="model.name">
     <!-- My record data -->
 </record>
 

--- a/template/module/demo/model_name_demo.xml
+++ b/template/module/demo/model_name_demo.xml
@@ -5,7 +5,7 @@
 <openerp>
 <data>
 
-<record id="my_demo_record" model="model.name">
+<record id="model_name_my_record_demo" model="model.name">
     <!-- My demo record data -->
 </record>
 

--- a/template/module/security/some_model_security.xml
+++ b/template/module/security/some_model_security.xml
@@ -5,11 +5,11 @@
 <openerp>
 <data>
 
-<record id="category" model="ir.module.category">
+<record id="ir_module_category_1" model="ir.module.category">
     <field name="name">Some model</field>
 </record>
 
-<record id="user_group" model="res.groups">
+<record id="res_groups_user" model="res.groups">
     <field name="name">User</field>
     <field name="category_id" ref="category"/>
     <field name="comment">
@@ -17,7 +17,7 @@
     </field>
 </record>
 
-<record id="manager_group" model="res.groups">
+<record id="res_groups_manager" model="res.groups">
     <field name="name">Manager</field>
     <field name="category_id" ref="category"/>
     <field name="implied_ids" eval="[(4, ref('user_group'))]"/>

--- a/template/module/views/model_name_view.xml
+++ b/template/module/views/model_name_view.xml
@@ -5,7 +5,17 @@
 <openerp>
 <data>
 
-<record id="my_view" model="ir.ui.view">
+<record id="model_name_view_form" model="ir.ui.view">
+    <field name="name">My view description</field>
+    <field name="model">model.name</field>
+    <field name="arch" type="xml">
+        <form string="My Data">
+            <!-- My view content -->
+        </form>
+    </field>
+</record>
+
+<record id="form_view" model="ir.ui.view">
     <field name="name">My view description</field>
     <field name="model">model.name</field>
     <field name="inherit_id" ref="othermodule.form_view"/>

--- a/template/module/wizards/wizard_model_view.xml
+++ b/template/module/wizards/wizard_model_view.xml
@@ -5,7 +5,7 @@
 <openerp>
 <data>
 
-<record id="wizard_model_view" model="ir.ui.view">
+<record id="wizard_model_view_form" model="ir.ui.view">
     <field name="name">My view description</field>
     <field name="model">module.wizard_model</field>
     <field name="arch" type="xml">


### PR DESCRIPTION
* Update module template to reflect new XML ID rules
* Correct several XML IDs in module template not following older style rules

This PR is connected to the new rules introduced in https://github.com/OCA/maintainer-tools/pull/272