### PR TITLE
[IMP] new convention for website key

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,10 @@ section.
   * Make sure it has the `license` and `images` keys.
   * Make sure the text `,Odoo Community Association (OCA)` is appended
     to the `author` text.
+  * The `website` key must be `https://github.com/OCA/<repo>/<addon>`,
+    so as to provide the most relevant link to discover more information about the addon.
+    That link shows the addon README which in turn shows proper credits (authors, contributors and theirs companies),
+    and links to the relevant information the OCA website.
 * Don't use your company logo or your corporate branding. Using the website, the author and the list of contributors is enough for people to know about your employer/company and contact you.
 
 ### Version numbers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ section.
     That link shows the repository README. Alternatively `https://github.com/OCA/<repo>/tree/<branch>/<addon>`
     may be used, to provide a direct link to the addon README, which includes proper credits
     (authors, contributors and theirs companies), and links to the relevant information on the OCA website.
-* Don't use your company logo or your corporate branding. Using the website, the author and the list of contributors is enough for people to know about your employer/company and contact you.
+* Don't use your company logo or your corporate branding. Using the author and the list of contributors is enough for people to know about your employer/company and contact you.
 
 ### Version numbers
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,10 +79,11 @@ section.
   * Make sure it has the `license` and `images` keys.
   * Make sure the text `,Odoo Community Association (OCA)` is appended
     to the `author` text.
-  * The `website` key must be `https://github.com/OCA/<repo>/<addon>`,
+  * The `website` key must be `https://github.com/OCA/<repo>`,
     so as to provide the most relevant link to discover more information about the addon.
-    That link shows the addon README which in turn shows proper credits (authors, contributors and theirs companies),
-    and links to the relevant information the OCA website.
+    That link shows the repository README. Alternatively `https://github.com/OCA/<repo>/tree/<branch>/<addon>`
+    may be used, to provide a direct link to the addon README, which includes proper credits
+    (authors, contributors and theirs companies), and links to the relevant information on the OCA website.
 * Don't use your company logo or your corporate branding. Using the website, the author and the list of contributors is enough for people to know about your employer/company and contact you.
 
 ### Version numbers

--- a/template/module/README.rst
+++ b/template/module/README.rst
@@ -65,8 +65,8 @@ Images
 Contributors
 ------------
 
-* Firstname Lastname <email.address@example.org>
-* Second Person <second.person@example.org>
+* Firstname Lastname <email.address@example.org> (optional company website url)
+* Second Person <second.person@example.org> (optional company website url)
 
 Funders
 -------

--- a/template/module/__openerp__.py
+++ b/template/module/__openerp__.py
@@ -6,7 +6,7 @@
     "summary": "Module summary",
     "version": "8.0.1.0.0",
     "category": "Uncategorized",
-    "website": "https://odoo-community.org/",
+    "website": "https://github.com/OCA/<repo>/<addon>",
     "author": "<AUTHOR(S)>, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "application": False,

--- a/template/module/__openerp__.py
+++ b/template/module/__openerp__.py
@@ -6,7 +6,7 @@
     "summary": "Module summary",
     "version": "8.0.1.0.0",
     "category": "Uncategorized",
-    "website": "https://github.com/OCA/<repo>/<addon>",
+    "website": "https://github.com/OCA/<repo>" or "https://github.com/OCA/<repo>/tree/<branch>/<addon>",
     "author": "<AUTHOR(S)>, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "application": False,


### PR DESCRIPTION
I hereby propose a new convention for the website key in the manifest.

The current tradition is to put the author company website or the OCA website. Neither of these provide directly relevant information about the addon. 

I therefore propose to use the link to the OCA github repository which provides direct access to the addon README which in turn provides immediate access to the most relevant information, including detailed authors and contributors information.