### PR TITLE
Remove phantom repo

### DIFF
--- a/tools/repos_with_ids.txt
+++ b/tools/repos_with_ids.txt
@@ -61,7 +61,6 @@
 95|github.com/OCA/account-invoicing
 112|github.com/OCA/department
 128|github.com/OCA/management-system
-170|github.com/OCA/connector-rt
 143|github.com/OCA/reporting-engine
 153|github.com/OCA/stock-logistics-warehouse
 145|github.com/OCA/rma


### PR DESCRIPTION
Repo 170 - connector-rt doesnot exist in Github
Removed
