### PR TITLE
[FIX] UICase Fixes

### DIFF
--- a/template/module/tests/test_something.py
+++ b/template/module/tests/test_something.py
@@ -29,9 +29,17 @@ class SomethingCase(TransactionCase):
 
 
 class UICase(HttpCase):
+
+    post_install = True
+    at_install = False
+
     def test_ui_web(self):
         """Test backend tests."""
-        self.phantom_js("/web/tests?debug=assets&module=module_name", "", login="admin")
+        self.phantom_js(
+            "/web/tests?debug=assets&module=module_name",
+            "",
+            login="admin",
+        )
 
     def test_ui_website(self):
         """Test frontend tour."""


### PR DESCRIPTION
* Add `post_install` and `at_install` keys
* Fix PEP

Not including the `post_install` and `at_install` keys can yield random errors, such as missing static QWeb templates.

Cc @hughesbm 