### PR TITLE
[REF] .travis.yml: Use distribution precise linux 12.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 # Config file .travis.yml
 
+dist: precise
+
 language: python
 
 python:


### PR DESCRIPTION
In order to fix https://github.com/OCA/maintainer-tools/pull/289#issuecomment-328924874