### PR TITLE
[ADD] missing "maintenance" in repos_with_ids.txt

### DIFF
--- a/tools/repos_with_ids.txt
+++ b/tools/repos_with_ids.txt
@@ -133,6 +133,7 @@
 237|github.com/OCA/l10n-vietnam
 238|github.com/OCA/l10n-thailand
 239|github.com/OCA/vertical-realstate
+240|github.com/OCA/maintenance
 248|github.com/OCA/mis-builder
 249|github.com/OCA/apps-store
 250|github.com/OCA/server-ux


### PR DESCRIPTION
"maintenance" repository (id=240) is missing in [repos_with_ids.txt](https://github.com/OCA/maintainer-tools/blob/master/tools/repos_with_ids.txt)
