### PR TITLE
[IMP] Add a `migration` label

### DIFF
--- a/tools/set_repo_labels.py
+++ b/tools/set_repo_labels.py
@@ -25,6 +25,7 @@ all_labels = {
     'approved': '045509',
     'work in progress': '0052cc',
     'wontfix': 'ffffff',
+    'migration': 'd4c5f9',
     }
 
 


### PR DESCRIPTION
* Add a `migration` label as light purple (#d4c5f9)

Any thoughts? Here's a screenshot of the color:

![image](https://user-images.githubusercontent.com/7397578/34503923-12e74698-efd0-11e7-892a-53bea04f2e2f.png)

 I don't think I've seen anything conflicting with it in any of the repos, but it's possible.