### PR TITLE
Ignore oca-custom in oca_projects.py

### DIFF
--- a/tools/oca_projects.py
+++ b/tools/oca_projects.py
@@ -186,6 +186,7 @@ def get_repositories():
         'OCB',
         'OpenUpgrade',
         'pylint-odoo',
+        'oca-custom',
     }
     gh = login()
     all_repos = [repo.name for repo in gh.iter_user_repos('OCA')


### PR DESCRIPTION
This repo is not subject to regular rules and in particular must not be published to pypi.