### PR TITLE
oca-copy-maintainers: manage PSC Representative team

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ ERPpeek==1.6.1
 PyYAML==3.11
 argparse==1.2.1
 bzr==2.7.0
-github3.py==0.9.4
+github3.py==0.9.6
 requests
 uritemplate.py==0.3.0
 inflection==0.3.1

--- a/tools/copy_maintainers.py
+++ b/tools/copy_maintainers.py
@@ -26,6 +26,7 @@ class FakeProject(object):
 
     @property
     def user_id(self):
+        return False
         return self._members[0] if self._members else False
 
     @property
@@ -35,7 +36,7 @@ class FakeProject(object):
 
 def get_cla_project(odoo):
     Partner = odoo.model('res.partner')
-    domain = [('x_github_login', '!=', False),
+    domain = [('github_login', '!=', False),
               '|',
               ('category_id.name', 'in', ('ICLA', 'ECLA')),
               ('parent_id.category_id.name', '=', 'ECLA')]
@@ -43,12 +44,59 @@ def get_cla_project(odoo):
     return FakeProject('OCA Contributors', members)
 
 
+class GHTeamList(object):
+    def __init__(self, gh_cnx=None, org='oca', dry_run=False):
+        if gh_cnx is None:
+            gh_cnx = github_login.login()
+        self._gh = gh_cnx
+        self._org = self._gh.organization('oca')
+        self._load_teams()
+        self.dry_run = dry_run
+
+    def _load_teams(self):
+        self._teams = {t.name: t for t in self._org.iter_teams()}
+
+    def get_project_team(self, project):
+        return self._teams.get(project.name)
+
+    def get_project_psc_team(self, project):
+        main_team = self.get_project_team(project)
+        name = project.name + u' PSC Representative'
+        team = self._teams.get(name)
+        if team is None and main_team is not None:
+            team = self.create_psc_team(project, name, main_team)
+        # sync repositories
+        if team:
+            for repo in main_team.iter_repos():
+                repo_name = '%s/%s' % (repo.owner.login, repo.name)
+                if not team.has_repo(repo_name):
+                    if not self.dry_run:
+                        status = team.add_repo(repo_name)
+                    else:
+                        status = False
+                    print('Added repo %s to team %s -> %s' %
+                          (repo_name, team.name,
+                           'OK' if status else 'NOK'))
+        print(list(r.name for r in team.iter_repos()))
+        return team
+
+    def create_psc_team(self, project, team_name, main_team):
+        repo_names = ['%s/%s' % (r.owner.login, r.name)
+                      for r in main_team.iter_repos()]
+        if not self.dry_run:
+            self._org.create_team(
+                name=team_name,
+                repo_names=repo_names,
+                permission='admin')
+        self._load_teams()
+        return self._teams.get(team_name)
+
+
 def get_members_project(odoo):
     Partner = odoo.model('res.partner')
-    domain = [('x_github_login', '!=', False),
+    domain = [('github_login', '!=', False),
               ('membership_state', 'in', ('paid', 'free'))]
     members = Partner.browse(domain)
-    print(members)
     return FakeProject('OCA Members', members)
 
 
@@ -58,7 +106,7 @@ def copy_users(odoo, team=None, dry_run=False):
     # on odoo, the model is a project, but they are teams on GitHub
     Project = odoo.model('project.project')
     base_domain = [('privacy_visibility = public'),
-                   ('state != template')]
+                   ]
     if team == 'OCA Contributors':
         projects = [get_cla_project(odoo)]
     elif team == 'OCA Members':
@@ -72,52 +120,41 @@ def copy_users(odoo, team=None, dry_run=False):
         projects = list(Project.browse(base_domain))
         projects.append(get_cla_project(odoo))
         projects.append(get_members_project(odoo))
-    print('Fetching teams...')
-    org = gh.organization('oca')
-    github_teams = list(org.iter_teams())
+    github_teams = GHTeamList(gh, org='oca', dry_run=dry_run)
     valid = []
     not_found = []
     for odoo_project in sorted(projects, key=attrgetter('name')):
-        for github_team in github_teams:
-            if github_team.name == odoo_project.name:
-                valid.append((odoo_project, github_team))
-                break
+        team = github_teams.get_project_team(odoo_project)
+        if team and odoo_project.user_id:
+            psc_team = github_teams.get_project_psc_team(odoo_project)
+        else:
+            psc_team = False
+        if team:
+            valid.append((odoo_project, team, psc_team))
         else:
             not_found.append(odoo_project)
 
     no_github_login = set()
-    for odoo_project, github_team in valid:
+    for odoo_project, github_team, psc_team in valid:
         print()
         print('Syncing project "%s"' % odoo_project.name)
-        users = [odoo_project.user_id]
-        users += odoo_project.members
-        logins = set(['oca-transbot',
-                      'OCA-git-bot',
-                      ])
+        psc_users = [odoo_project.user_id] if odoo_project.user_id else []
+        users = psc_users + list(odoo_project.members)
+        user_logins = set(['oca-transbot',
+                           'OCA-git-bot',
+                           ])
+        psc_user_logins = set()
         for user in users:
-            if user.x_github_login:
-                logins.add(user.x_github_login)
+            if user.github_login:
+                user_logins.add(user.github_login)
             else:
                 no_github_login.add("%s (%s)" % (user.name, user.login))
-        current_logins = set(user.login for user in github_team.iter_members())
-
-        keep_logins = logins.intersection(current_logins)
-        remove_logins = current_logins - logins
-        add_logins = logins - current_logins
-        print("Add   ", colors.GREEN + ', '.join(add_logins) + colors.ENDC)
-        print("Keep  ", ', '.join(keep_logins))
-        print("Remove", colors.FAIL + ', '.join(remove_logins) + colors.ENDC)
-        if not dry_run:
-            for login in add_logins:
-                try:
-                    github_team.invite(login)
-                except Exception as exc:
-                    print('Failed to invite %s: %s' % (login, exc))
-            for login in remove_logins:
-                try:
-                    github_team.remove_member(login)
-                except Exception as exc:
-                    print('Failed to remove %s: %s' % (login, exc))
+        for user in psc_users:
+            if user.github_login:
+                psc_user_logins.add(user.github_login)
+        sync_team(github_team, user_logins, dry_run)
+        if psc_team:
+            sync_team(psc_team, psc_user_logins, dry_run)
 
     if no_github_login:
         print()
@@ -130,6 +167,33 @@ def copy_users(odoo, team=None, dry_run=False):
         print('The following odoo projects have no team in GitHub:')
         for project in not_found:
             print(project.name)
+
+
+def sync_team(team, logins, dry_run=False):
+    print(team.name)
+    current_logins = set(user.login for user in team.iter_members())
+
+    keep_logins = logins.intersection(current_logins)
+    remove_logins = current_logins - logins
+    add_logins = logins - current_logins
+    print("Add   ", (colors.GREEN +
+                     ', '.join(add_logins) +
+                     colors.ENDC))
+    print("Keep  ", ', '.join(keep_logins))
+    print("Remove", (colors.FAIL +
+                     ', '.join(remove_logins) +
+                     colors.ENDC))
+    if not dry_run:
+        for login in add_logins:
+            try:
+                team.invite(login)
+            except Exception as exc:
+                print('Failed to invite %s: %s' % (login, exc))
+        for login in remove_logins:
+            try:
+                team.remove_member(login)
+            except Exception as exc:
+                print('Failed to remove %s: %s' % (login, exc))
 
 
 def main():

--- a/tools/odoo_login.py
+++ b/tools/odoo_login.py
@@ -9,7 +9,7 @@ from . config import read_config, write_config
 
 
 ODOO_URL = 'https://odoo-community.org'
-ODOO_DB = 'openerp_oca_prod'
+ODOO_DB = 'odoo_community_v10'
 
 
 def login(username, store):


### PR DESCRIPTION
At the request of the Board, I changed the script to handle a team for the PSC Representative of the projects. With this version, a team is created (if needed) for the PSC Representative with the proper access, and synchronised with the normal team, and the PSC Representative is added to the team. 

Result: 
![image](https://user-images.githubusercontent.com/2032807/35768635-4114fbbc-08ff-11e8-9678-d19107fe0449.png)
