### PR TITLE
[RM] encoding=utf-8 is not needed anymore in Python 3

### DIFF
--- a/template/module/demo/assets.xml
+++ b/template/module/demo/assets.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0"?>
 <!-- Copyright <YEAR(S)> <AUTHOR(S)>
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 


### PR DESCRIPTION
### Milestone (Odoo version)
- 11.0

### New features
- UTF-8 as the default source encoding for Python 3.x.
