### PR TITLE
Remove license from __init__.py

### DIFF
--- a/template/module/__init__.py
+++ b/template/module/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import models
 from . import wizards


### PR DESCRIPTION
Usually license and authorship are not to be added in __init__.py as they are not supposed to contain code.
