### PR TITLE
Add Table of contents separator in README template

### DIFF
--- a/tools/gen_addon_readme.template
+++ b/tools/gen_addon_readme.template
@@ -26,6 +26,8 @@
 {% for _ in badges %}|badge{{ loop.index }}| {% endfor %}
 
 {{ fragments.get('DESCRIPTION', '') }}
+**Table of contents**
+
 .. contents::
    :local:
 


### PR DESCRIPTION
Without that, it looks weird when DESCRIPTION.rst itself
ends with a bullet list.