### PR TITLE
add oca-travis to copy-maintainers

### DIFF
--- a/tools/copy_maintainers.py
+++ b/tools/copy_maintainers.py
@@ -143,6 +143,7 @@ def copy_users(odoo, team=None, dry_run=False):
         users = psc_users + list(odoo_project.members)
         user_logins = set(['oca-transbot',
                            'OCA-git-bot',
+                           'oca-travis',
                            ])
         psc_user_logins = set()
         for user in users:


### PR DESCRIPTION
oca-travis is the user used in travis scripts to push back changes to github, it must be a member of the Core Maintainers team.

cc/ @gurneyalex 