### PR TITLE
readme generator: ignore empty fragments

### DIFF
--- a/tools/gen_addon_readme.py
+++ b/tools/gen_addon_readme.py
@@ -107,7 +107,11 @@ def gen_one_addon_readme(repo_name, branch, addon_name, addon_dir, manifest):
         )
         if os.path.exists(fragment_filename):
             with io.open(fragment_filename, 'rU', encoding='utf8') as f:
-                fragments[fragment_name] = f.read()
+                fragment = f.read()
+                if fragment:
+                    if fragment[-1] != '\n':
+                        fragment += '\n'
+                    fragments[fragment_name] = fragment
     runbot_id = get_runbot_ids()[repo_name]
     badges = []
     development_status = manifest.get('development_status', 'Beta')


### PR DESCRIPTION
As well as auto add missing newline at eof, to avoid
rst syntax errors.