### PR TITLE
[IMP] read runbot ids online

### DIFF
--- a/tools/runbot_ids.py
+++ b/tools/runbot_ids.py
@@ -1,19 +1,22 @@
 # Copyright (c) 2018 ACSONE SA/NV
 # License AGPLv3 (http://www.gnu.org/licenses/agpl-3.0-standalone.html)
-import os
 import re
 
+import requests
 
 REPO_ID_LINE_RE = \
     re.compile(r'^(?P<repo_id>[0-9]+)\|github\.com/OCA/(?P<repo_name>.*)')
+
+REPOS_WITH_IDS_URL = \
+    'https://raw.githubusercontent.com/OCA/maintainer-tools/' \
+    'master/tools/repos_with_ids.txt'
 
 
 def get_runbot_ids():
     """ return a dictionary of runbot id by project name """
     res = {}
-    repos_with_ids = \
-        os.path.join(os.path.dirname(__file__), 'repos_with_ids.txt')
-    for repo_id_line in open(repos_with_ids, "rU"):
+    repos_with_ids = requests.get(REPOS_WITH_IDS_URL).text
+    for repo_id_line in repos_with_ids.split('\n'):
         repo_id_line = repo_id_line.strip()
         mo = REPO_ID_LINE_RE.match(repo_id_line)
         if not mo:


### PR DESCRIPTION
This is to avoid redeploying maintainer-tools on the oca server for the bot each time a new repo is added.