### PR TITLE
Correction of default value for <<Transifex, num_retries>>

### DIFF
--- a/tools/config.py
+++ b/tools/config.py
@@ -19,7 +19,7 @@ def init_config():
     config.add_section("Transifex")
     config.set("Transifex", "username", "transbot@odoo-community.org")
     config.set("Transifex", "password", "")
-    config.set("Transifex", "num_retries", 3)
+    config.set("Transifex", "num_retries", "3")
     config.set("Transifex", "organization", "OCA")
     write_config(config)
 


### PR DESCRIPTION
### Milestone (Odoo version)
- 11

### Module(s)
- OCA/maintainer-tools

### Fixes / new features
- Correction of default value for "Transifex", "num_retries", 3 must be in string format "3"


