### PR TITLE
Improve python 3 compatibility

### DIFF
--- a/tools/pypi_upload.py
+++ b/tools/pypi_upload.py
@@ -2,11 +2,18 @@
 # License AGPLv3 (http://www.gnu.org/licenses/agpl-3.0-standalone.html)
 from __future__ import print_function
 import contextlib
-import dumbdbm
+try:
+    import dbm.dumb as dumbdbm
+except ImportError:
+    # python 2
+    import dumbdbm
 import logging
 import os
 import subprocess
-from ConfigParser import RawConfigParser
+try:
+    from configparser import RawConfigParser
+except ImportError:
+    from ConfigParser import RawConfigParser
 
 from wheel.install import WheelFile
 from pkg_resources import parse_version


### PR DESCRIPTION
This makes oca-main-branch-bot python 3 compatible while still being able to run on python 2 branches.

This is necessary to support some 11.0 manifest that have non ascii characters in name or authors, and can be parsed by python 3 and not python2.