### PR TITLE
[FIX] readme generator: use anymous hyperlink

### DIFF
--- a/tools/gen_addon_readme.template
+++ b/tools/gen_addon_readme.template
@@ -81,7 +81,7 @@ promote its widespread use.
     :alt: {{ maintainer}}
 {%- endfor %}
 
-Current `maintainer{% if manifest.maintainers|length > 1 %}s{% endif %} <https://odoo-community.org/page/maintainer-role>`_:
+Current `maintainer{% if manifest.maintainers|length > 1 %}s{% endif %} <https://odoo-community.org/page/maintainer-role>`__:
 
 {% for maintainer in manifest.maintainers %}|maintainer-{{ maintainer }}| {% endfor -%}
 {% endif %}


### PR DESCRIPTION
To avoid a duplicate implicit target error (conflicting
with the Maintainers section title) when there is more
than one maintainer.

fixes #364 
