### PR TITLE
Relax setuptools version constraint.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,11 +38,6 @@ setuptools.setup(
         'setuptools-odoo>=2.1',
         'twine',
         'wheel',
-        # We keep setuptools<31 as long as we can, so
-        # generated wheel continue to work for Odoo 10
-        # without odoo-autodiscover 2.
-        # https://github.com/odoo/odoo/pull/15718
-        'setuptools<31',
     ],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     classifiers=[


### PR DESCRIPTION
Requiring setuptools<31 now breaks travis builds. This was bound to happen
sooner or later. Allowing the latest setuptools version
has only one drawback: it obliges people using wheels built
with recent versions to always use odoo-autodiscover>=2 on Odoo<11.
This is the safest and easiest anyway and it is best practice
so most people should be unaffected.