### PR TITLE
[IMP] oca-gen-addon-readme : make organization name configurable and fix images URL

### DIFF
--- a/template/module/readme/CONFIGURE.rst
+++ b/template/module/readme/CONFIGURE.rst
@@ -5,6 +5,6 @@ To configure this module, you need to:
 
 #. Go to ...
 
-.. figure:: path/to/local/image.png
+.. figure:: ../static/description/image.png
    :alt: alternative description
    :width: 600 px

--- a/tools/gen_addon_readme.py
+++ b/tools/gen_addon_readme.py
@@ -5,16 +5,23 @@
 import io
 import os
 import re
+import sys
 
 import click
 from docutils import ApplicationError
 from docutils.core import publish_file
 from jinja2 import Template
-from urllib.parse import urljoin
 
 from .gitutils import commit_if_needed
 from .manifest import read_manifest, find_addons, NoManifestFound
 from .runbot_ids import get_runbot_ids
+
+if sys.version_info[0] < 3:
+    # python 2 import
+    from urlparse import urljoin
+else:
+    # python 3 import
+    from urllib.parse import urljoin
 
 
 FRAGMENTS_DIR = 'readme'

--- a/tools/gen_addon_readme.py
+++ b/tools/gen_addon_readme.py
@@ -266,8 +266,10 @@ def gen_one_addon_index(readme_filename):
                    "generated for all installable addons found there.")
 @click.option('--commit/--no-commit',
               help="git commit changes to README.rst, if any.")
+@click.option('--gen-html/--no-gen-html', default=True,
+              help="Generate index html file.")
 def gen_addon_readme(
-        org_name, repo_name, branch, addon_dirs, addons_dir, commit):
+        org_name, repo_name, branch, addon_dirs, addons_dir, commit, gen_html):
     """ Generate README.rst from fragments.
 
     Do nothing if readme/DESCRIPTION.rst is absent, otherwise overwrite
@@ -293,9 +295,10 @@ def gen_addon_readme(
         readme_filename = gen_one_addon_readme(
             org_name, repo_name, branch, addon_name, addon_dir, manifest)
         readme_filenames.append(readme_filename)
-        index_filename = gen_one_addon_index(readme_filename)
-        if index_filename:
-            readme_filenames.append(index_filename)
+        if gen_html:
+            index_filename = gen_one_addon_index(readme_filename)
+            if index_filename:
+                readme_filenames.append(index_filename)
     if commit:
         commit_if_needed(readme_filenames, '[UPD] README.rst')
 

--- a/tools/gen_addon_readme.py
+++ b/tools/gen_addon_readme.py
@@ -138,9 +138,12 @@ def generate_fragment(org_name, repo_name, branch, addon_name, file):
     module_url = "https://raw.githubusercontent.com/{org_name}/{repo_name}"\
         "/{branch}/{addon_name}/".format(**locals())
     for index, fragment_line in enumerate(fragment_lines):
-        if fragment_line.startswith('.. figure::'):
-            path =\
-                fragment_line.replace('\n', '').replace('.. figure:: ', '')
+        if ('.. figure::' in fragment_line or
+                '.. image::' in fragment_line):
+            path = fragment_line.strip()\
+                .replace('\n', '')\
+                .replace('.. figure:: ', '')\
+                .replace('.. image:: ', '')
             if path.startswith('http'):
                 # It is already an absolute path
                 continue

--- a/tools/gen_addon_readme.py
+++ b/tools/gen_addon_readme.py
@@ -1,5 +1,7 @@
 # License AGPLv3 (http://www.gnu.org/licenses/agpl-3.0-standalone.html)
 # Copyright (c) 2018 ACSONE SA/NV
+# Copyright (c) 2018 GRAP (http://www.grap.coop)
+
 import io
 import os
 import re

--- a/tools/gen_addon_readme.py
+++ b/tools/gen_addon_readme.py
@@ -8,7 +8,7 @@ import click
 from docutils import ApplicationError
 from docutils.core import publish_file
 from jinja2 import Template
-from urlparse import urljoin
+from urllib.parse import urljoin
 
 from .gitutils import commit_if_needed
 from .manifest import read_manifest, find_addons, NoManifestFound

--- a/tools/gen_addon_readme.template
+++ b/tools/gen_addon_readme.template
@@ -40,10 +40,10 @@
 Bug Tracker
 ===========
 
-Bugs are tracked on `GitHub Issues <https://github.com/OCA/{{ repo_name }}/issues>`_.
+Bugs are tracked on `GitHub Issues <https://github.com/{{ org_name }}/{{ repo_name }}/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
-`feedback <https://github.com/OCA/{{ repo_name }}/issues/new?body=module:%20{{ addon_name }}%0Aversion:%20{{ branch }}%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+`feedback <https://github.com/{{ org_name }}/{{ repo_name }}/issues/new?body=module:%20{{ addon_name }}%0Aversion:%20{{ branch }}%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Do not contact contributors directly about support or help with technical issues.
 
@@ -64,6 +64,7 @@ Authors
 Maintainers
 ~~~~~~~~~~~
 
+{% if org_name == 'OCA' %}
 This module is maintained by the OCA.
 
 .. image:: https://odoo-community.org/logo.png
@@ -73,6 +74,7 @@ This module is maintained by the OCA.
 OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
+{% endif %}
 
 {%- if manifest.maintainers %}
 {% for maintainer in manifest.maintainers %}
@@ -86,7 +88,6 @@ Current `maintainer{% if manifest.maintainers|length > 1 %}s{% endif %} <https:/
 {% for maintainer in manifest.maintainers %}|maintainer-{{ maintainer }}| {% endfor -%}
 {% endif %}
 
-This module is part of the `OCA/{{ repo_name }} <https://github.com/OCA/{{ repo_name }}/tree/{{ branch }}/{{ addon_name }}>`_ project on GitHub.
+This module is part of the `{{ org_name }}/{{ repo_name }} <https://github.com/{{ org_name }}/{{ repo_name }}/tree/{{ branch }}/{{ addon_name }}>`_ project on GitHub.
 
-You are welcome to contribute. To learn how please visit https://odoo-community.org/page/Contribute.
-
+You are welcome to contribute.{% if org_name == 'OCA' %} To learn how please visit https://odoo-community.org/page/Contribute.{% endif %}

--- a/tools/gen_addon_readme.template
+++ b/tools/gen_addon_readme.template
@@ -64,7 +64,7 @@ Authors
 Maintainers
 ~~~~~~~~~~~
 
-{% if org_name == 'OCA' %}
+{% if org_name == 'OCA' -%}
 This module is maintained by the OCA.
 
 .. image:: https://odoo-community.org/logo.png
@@ -74,7 +74,7 @@ This module is maintained by the OCA.
 OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
-{% endif %}
+{%- endif %}
 
 {%- if manifest.maintainers %}
 {% for maintainer in manifest.maintainers %}
@@ -90,4 +90,11 @@ Current `maintainer{% if manifest.maintainers|length > 1 %}s{% endif %} <https:/
 
 This module is part of the `{{ org_name }}/{{ repo_name }} <https://github.com/{{ org_name }}/{{ repo_name }}/tree/{{ branch }}/{{ addon_name }}>`_ project on GitHub.
 
-You are welcome to contribute.{% if org_name == 'OCA' %} To learn how please visit https://odoo-community.org/page/Contribute.{% endif %}
+{% if org_name == 'OCA' -%}
+You are welcome to contribute. To learn how please visit https://odoo-community.org/page/Contribute.
+
+{%- else %}
+You are welcome to contribute.
+
+{%- endif %}
+


### PR DESCRIPTION
Hi all, 

First, thanks for this great tool.

This PR adds 2 improvements on oca-gen-addon-readme (the second depends on the first).

Commit 1 : make the organization name configurable, to let the possibility to generate readme for incubator / custom repositories. (= non OCA repo)

for that purpose, 
-> add a new argument ``--org-name`` with default value set to ``OCA``
-> replace hard coded 'OCA' by the org_name, in all the URLs
-> hide some parts of the template, if the organization is not OCA

Commit 2 : Fix a recurring trouble on figures. In a few words, relative path of figures are not working in the same time on github, on odoo, and on odoo appstore. So, add a little script to translate relative path into full github path. (using rawcontent).
For the time being, to make the image available in all places, maintainers has to write absolute url. (sample in mis-builder : https://raw.githubusercontent.com/OCA/mis-builder/10.0/mis_builder/readme/USAGE.rst)
but the problem are : 
- the url depends on version, so should be changed in each new release ;
- doesnt work on github, when the PR is not merged ; (harder to review)
- longer url ;

sample of the generated code, for a non OCA module : 
https://github.com/grap/grap-odoo-incubator/tree/8.0/account_invoice_supplierinfo_update_triple_discount

(DESCRIPTION.rst contains relative path, and generated readme contains absolute path)


thanks for your review. CC : @sbidoul 
