### PR TITLE
[FIX] allow images in table, and shortcut usage

### DIFF
--- a/tools/gen_addon_readme.py
+++ b/tools/gen_addon_readme.py
@@ -145,7 +145,8 @@ def generate_fragment(org_name, repo_name, branch, addon_name, file):
         return False
 
     # Replace relative path by absolute path for figures
-    image_path_re = re.compile(r'\s*\.\. (figure|image)::\s+(?P<path>.*?)\s*$')
+    image_path_re = re.compile(
+        r'.*\s*\.\..* (figure|image)::\s+(?P<path>.*?)\s*$')
     module_url = "https://raw.githubusercontent.com/{org_name}/{repo_name}"\
         "/{branch}/{addon_name}/".format(**locals())
     for index, fragment_line in enumerate(fragment_lines):


### PR DESCRIPTION
Trivial patch to
- allow images in table.
- allow shortcut on images. (add ``|shortcut|`` before the image.) 

(the regex doesn't match for the time being)

Note I need it to generate this readme file : 
https://github.com/legalsylvain/stock-logistics-barcode/tree/11.0_ADD_mobile_app_picking/mobile_app_picking


Thanks.