### PR TITLE
[IMP] do not fail if setup directory is absent

### DIFF
--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -18,5 +18,4 @@ def test_manifest_find_addons():
 def test_manifest_find_addons_uninstallable():
     addons = list(manifest.find_addons(TEST_REPO_DIR, installable_only=False))
     assert len(addons) == 2
-    assert addons[0][0] == 'module1'
-    assert addons[1][0] == 'module2'
+    assert set((addons[0][0], addons[1][0])) == set(('module1', 'module2'))

--- a/tools/main_branch_bot.py
+++ b/tools/main_branch_bot.py
@@ -59,16 +59,17 @@ def main(target, repo, branch, push, python2):
             try:
                 # make dists and wheels for each installable addon
                 # and _metapackage
-                sys.stderr.write(
-                    "============> dist_to_simple_index in %s@%s\n" %
-                    (repo, branch),
-                )
-                setup_dirs = [opj('setup', d) for d in os.listdir('setup')]
-                dist_to_simple_index(
-                    target, setup_dirs,
-                    # use the right python to generate wheels
-                    python=_get_python(branch, python2),
-                )
+                if os.path.isdir('setup'):
+                    sys.stderr.write(
+                        "============> dist_to_simple_index in %s@%s\n" %
+                        (repo, branch),
+                    )
+                    setup_dirs = [opj('setup', d) for d in os.listdir('setup')]
+                    dist_to_simple_index(
+                        target, setup_dirs,
+                        # use the right python to generate wheels
+                        python=_get_python(branch, python2),
+                    )
             except Exception:
                 exit_code = 1
                 sys.stderr.write(


### PR DESCRIPTION
Useful for empty repos.