### PR TITLE
[ADD] tools: icon generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,15 @@ You may also use this script for your own repositories by specifying this
 additional argument `--org-name=myorganisation`
 
 
+### Icon generator
+
+To provide an icon for our modules we generate them automatically.
+
+To generate the icon for the module `auth_keycloak`:
+
+    $ oca-gen-addon-icon --addon-dir=auth_keycloak
+
+
 ### Auto fix pep8 guidelines
 
 To auto fix pep8 guidelines of your code you can run:

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setuptools.setup(
             'oca-pypi-upload = tools.pypi_upload:cli',
             'oca-dist-to-simple-index = tools.dist_to_simple_index:main',
             'oca-gen-addon-readme = tools.gen_addon_readme:gen_addon_readme',
+            'oca-gen-addon-icon = tools.gen_addon_icon:gen_addon_icon',
         ],
     },
 )

--- a/tests/test_gen_addon_icon.py
+++ b/tests/test_gen_addon_icon.py
@@ -1,0 +1,26 @@
+# License AGPLv3 (http://www.gnu.org/licenses/agpl-3.0-standalone.html)
+# Copyright (c) 2019 Eficent Business and IT Consulting Services S.L.
+#        (http://www.eficent.com)
+
+import os
+import subprocess
+import sys
+
+from tools.gen_addon_icon import ICONS_DIR, ICON_TYPE
+
+
+def test_gen_addon_icon(tmp_path):
+    addon_dir = tmp_path / "addon"
+    addon_dir.mkdir()
+    with (addon_dir / "__manifest__.py").open("w") as f:
+        f.write(u"{'name': 'addon'}")
+    cmd = [
+        sys.executable,
+        "-m",
+        "tools.gen_addon_icon",
+        "--addon-dir",
+        str(addon_dir),
+    ]
+    subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+    assert os.path.exists(
+        os.path.join(addon_dir._str, ICONS_DIR, 'icon.%s' % ICON_TYPE))

--- a/tools/gen_addon_icon.py
+++ b/tools/gen_addon_icon.py
@@ -1,0 +1,80 @@
+# License AGPLv3 (http://www.gnu.org/licenses/agpl-3.0-standalone.html)
+# Copyright (c) 2019 Eficent Business and IT Consulting Services S.L.
+#        (http://www.eficent.com)
+
+import os
+import shutil
+import click
+
+from .gitutils import commit_if_needed
+from .manifest import read_manifest, find_addons, NoManifestFound
+
+
+ICONS_DIR = os.path.join('static', 'description')
+
+ICON_TYPE = 'png'
+
+ICON_TYPES = ['png', 'svg']
+
+
+def gen_one_addon_icon(icon_dir, filetype=ICON_TYPE):
+    icon_filename = os.path.join(icon_dir, 'icon.%s' % filetype)
+    template_filename = \
+        os.path.join(os.path.dirname(__file__).rpartition('tools')[0],
+                     'template', 'module',
+                     ICONS_DIR, 'icon.%s' % filetype)
+    if os.path.exists(template_filename):
+        if not os.path.exists(icon_dir):
+            os.makedirs(icon_dir)
+        shutil.copyfile(template_filename, icon_filename)
+    return icon_filename
+
+
+@click.command()
+@click.option('--addon-dir', 'addon_dirs',
+              type=click.Path(dir_okay=True, file_okay=False, exists=True),
+              multiple=True,
+              help="Directory where addon manifest is located. This option "
+                   "may be repeated.")
+@click.option('--addons-dir',
+              type=click.Path(dir_okay=True, file_okay=False, exists=True),
+              help="Directory containing several addons, the icon will be "
+                   "put for all installable addons found there.")
+@click.option('--commit/--no-commit',
+              help="git commit icon, if not any.")
+def gen_addon_icon(addon_dirs, addons_dir, commit):
+    """ Put default OCA icon of type ICON_TYPE.
+
+    Do nothing if the icon already exists in ICONS_DIR, otherwise put
+    the default icon.
+    """
+    addons = []
+    if addons_dir:
+        addons.extend(find_addons(addons_dir))
+    for addon_dir in addon_dirs:
+        addon_name = os.path.basename(os.path.abspath(addon_dir))
+        try:
+            manifest = read_manifest(addon_dir)
+        except NoManifestFound:
+            continue
+        addons.append((addon_name, addon_dir, manifest))
+    icon_filenames = []
+    for addon_name, addon_dir, manifest in addons:
+        icon_dir = os.path.join(addon_dir, ICONS_DIR)
+        exist = False
+        for icon_type in ICON_TYPES:
+            icon_filename = os.path.join(icon_dir, 'icon.%s' % icon_type)
+            if os.path.exists(icon_filename):
+                # icon was created manually
+                exist = True
+                break
+        if exist:
+            continue
+        icon_filename = gen_one_addon_icon(icon_dir)
+        icon_filenames.append(icon_filename)
+    if commit:
+        commit_if_needed(icon_filenames, '[ADD] icon.%s' % ICON_TYPE)
+
+
+if __name__ == '__main__':
+    gen_addon_icon()


### PR DESCRIPTION
### Icon generator

To provide an icon for our modules we generate them automatically.

To generate the icon for the module `auth_keycloak`:

    $ oca-gen-addon-icon --addon-dir=auth_keycloak

----
My idea is to implement it after in the OCA github bot.