### PR TITLE
[FIX] tools.gen_addon_readme: deduplicate manifest reading

### DIFF
--- a/tools/gen_addon_readme.py
+++ b/tools/gen_addon_readme.py
@@ -295,14 +295,13 @@ def gen_addon_readme(
         addons.extend(find_addons(addons_dir))
     for addon_dir in addon_dirs:
         addon_name = os.path.basename(os.path.abspath(addon_dir))
-        manifest = read_manifest(addon_dir)
-        addons.append((addon_name, addon_dir, manifest))
-    readme_filenames = []
-    for addon_name, addon_dir, manifest in addons:
         try:
             manifest = read_manifest(addon_dir)
         except NoManifestFound:
             continue
+        addons.append((addon_name, addon_dir, manifest))
+    readme_filenames = []
+    for addon_name, addon_dir, manifest in addons:
         if not os.path.exists(
                 os.path.join(addon_dir, FRAGMENTS_DIR, 'DESCRIPTION.rst')):
             continue


### PR DESCRIPTION
Problem:
The code it's reading the manifest twice. The second is in the `try` one.
Thus, the first reading of the manifest is useless. Furthermore, you may have an unexpected `NoManifestFound` error in the first reading because the absence of the `try`.

Solution:
Delete the second one and put a `try` in the first.
