### PR TITLE
[FIX] informative url to already existing tokens during authentication

### DIFF
--- a/tools/github_login.py
+++ b/tools/github_login.py
@@ -58,7 +58,7 @@ def authorize_token(user):
                 if error['code'] == 'already_exists':
                     msg = ("The 'OCA (odoo community association) Maintainers "
                            "Tools' token already exists. You will find it at "
-                           "https://github.com/settings/applications and can "
+                           "https://github.com/settings/tokens and can "
                            "revoke it or set the token manually in the "
                            "configuration file.")
                     sys.exit(msg)


### PR DESCRIPTION
Fix info URL provided after wrong authentication caused by already existing token.