### PR TITLE
[FIX] pypi uploader: ensure unicode twine output

### DIFF
--- a/tools/pypi_upload.py
+++ b/tools/pypi_upload.py
@@ -89,7 +89,9 @@ class OcaPypi(object):
                '-r', self.repository, '--skip-existing', distfilename]
         if not self.dryrun:
             try:
-                subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+                subprocess.check_output(
+                    cmd, stderr=subprocess.STDOUT, universal_newlines=True
+                )
             except subprocess.CalledProcessError as e:
                 if "HTTPError: 400 Client Error" in e.output:
                     return e.output


### PR DESCRIPTION
For python 3 compatibility
