### PR TITLE
[ADD] manifest: preloadable flag

### DIFF
--- a/template/module/__manifest__.py
+++ b/template/module/__manifest__.py
@@ -15,6 +15,7 @@
     "license": "AGPL-3",
     "application": False,
     "installable": True,
+    "preloadable": True,
     "pre_init_hook": "pre_init_hook",
     "post_init_hook": "post_init_hook",
     "post_load": "post_load",

--- a/tools/gen_addon_icon.py
+++ b/tools/gen_addon_icon.py
@@ -61,6 +61,8 @@ def gen_addon_icon(addon_dirs, addons_dir, commit):
         addons.append((addon_name, addon_dir, manifest))
     icon_filenames = []
     for addon_name, addon_dir, manifest in addons:
+        if not manifest.get('preloadable', True):
+            continue
         icon_dir = os.path.join(addon_dir, ICONS_DIR)
         exist = False
         for icon_type in ICON_TYPES:


### PR DESCRIPTION
Odoo does things if the module has a static folder. See https://github.com/OCA/OCB/blob/11.0/odoo/http.py#L1340.

Modules with `'preloadable': False` should not have a static folder.