### PR TITLE
[ADD] 'excludes' key in manifest file

### DIFF
--- a/template/module/__manifest__.py
+++ b/template/module/__manifest__.py
@@ -27,6 +27,10 @@
     "depends": [
         "base",
     ],
+    # this feature is only present for 11.0+
+    "excludes": [
+        "module_name",
+    ],
     "data": [
         "security/some_model_security.xml",
         "security/ir.model.access.csv",


### PR DESCRIPTION
### Milestone (Odoo version)
-  11.0+

### Fixes / new features
- Add 'excludes' key in manifest file to avoid conflicts between modules

CC @pedrobaeza 
