### PR TITLE
Add a warning in readme for Alpha status

### DIFF
--- a/tools/gen_addon_readme.py
+++ b/tools/gen_addon_readme.py
@@ -228,6 +228,7 @@ def gen_one_addon_readme(
             org_name=org_name,
             repo_name=repo_name,
             runbot_id=runbot_id,
+            development_status=development_status,
         ))
     return readme_filename
 

--- a/tools/gen_addon_readme.template
+++ b/tools/gen_addon_readme.template
@@ -26,6 +26,15 @@
 {% for _ in badges %}|badge{{ loop.index }}| {% endfor %}
 
 {{ fragments.get('DESCRIPTION', '') }}
+{% if development_status == 'Alpha' -%}
+
+.. IMPORTANT::
+   This is an alpha version, the data model and design can change at any time without warning.
+   Only for development or testing purpose, do not use in production.
+   `More details on development status <https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/oca_module_lifecycle_development_status.rst>`_
+
+{% endif -%}
+
 **Table of contents**
 
 .. contents::


### PR DESCRIPTION
The Alpha badge is visible but not enough to get people aware
of the consequences of using Alpha addons.