### PR TITLE
Provide pre-commit hooks, compatible with prettier

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,20 @@
+- id: oca-gen-addon-readme
+  name: Generate addons README files from fragments
+  always_run: true
+  entry: oca-gen-addon-readme
+  language: python
+  pass_filenames: false
+
+- id: oca-gen-addons-table
+  name: Generate addons table in README
+  always_run: true
+  entry: oca-gen-addons-table
+  language: python
+  pass_filenames: false
+
+- id: oca-gen-addon-icon
+  name: Generate addons icons
+  always_run: true
+  entry: oca-gen-addon-icon
+  language: python
+  pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ To generate the final README for the module `auth_keycloak`:
 
 The result will be a fully PyPI compliant README.rst in the root of your module.
 
-You may also use this script for your own repositories by specifying this 
+You may also use this script for your own repositories by specifying this
 additional argument `--org-name=myorganisation`
 
 
@@ -171,3 +171,32 @@ egg.
 You can use the `GITHUB_TOKEN` environment variable to specify the token
 
     $ GITHUB_TOKEN=xxx python -m tools.copy_maintainers
+
+## Integration with `pre-commit`
+
+In any addons repo, you can use these pre-commit hooks:
+
+```yaml
+# .pre-commit-config.yaml file
+repos:
+  - repo: https://github.com/OCA/maintainer-tools
+    rev: master # This is just an example; you must use a tag/commit instead!
+    hooks:
+      # Use each script's `--help` to understand the args
+      - id: oca-gen-addon-readme
+        args:
+          - --addons-dir=.
+          - --org-name=OCA
+          - --repo-name=server-tools
+          - --branch=13.0
+
+      # This job could easily produce conflicts when it runs on every commit,
+      # so it's added as a manual job. If you automate it, beware.
+      # See https://pre-commit.com/#confining-hooks-to-run-at-certain-stages
+      - id: oca-gen-addons-table
+        stages: [manual]
+
+      - id: oca-gen-addon-icon
+        args:
+          - --addons-dir=.
+```


### PR DESCRIPTION
### Fixes / new features
- oca-gen-addons-table now supports setting `--readme` and `--addons-dir` paths, to support non-oca repos structures.
- It also supports a more helpful `--help`, which also suggests you to add [prettier exlusion tags](https://prettier.io/docs/en/ignore.html#markdown), to avoid double-edition of README.md files.
- pre-commit hooks supplied and documented.

@Tecnativa @sbidoul 
