### PR TITLE
[RM] encoding=utf-8 is not needed anymore in Python 3.x+

### DIFF
--- a/template/module/__init__.py
+++ b/template/module/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import models

--- a/template/module/__manifest__.py
+++ b/template/module/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright <YEAR(S)> <AUTHOR(S)>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {

--- a/template/module/controllers/__init__.py
+++ b/template/module/controllers/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import main

--- a/template/module/controllers/main.py
+++ b/template/module/controllers/main.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright <YEAR(S)> <AUTHOR(S)>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 

--- a/template/module/exceptions.py
+++ b/template/module/exceptions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright <YEAR(S)> <AUTHOR(S)>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 

--- a/template/module/hooks.py
+++ b/template/module/hooks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright <YEAR(S)> <AUTHOR(S)>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 

--- a/template/module/models/__init__.py
+++ b/template/module/models/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import model_name

--- a/template/module/models/abstract_something.py
+++ b/template/module/models/abstract_something.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright <YEAR(S)> <AUTHOR(S)>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 

--- a/template/module/models/model_name.py
+++ b/template/module/models/model_name.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright <YEAR(S)> <AUTHOR(S)>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 

--- a/template/module/report/__init__.py
+++ b/template/module/report/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import report_name

--- a/template/module/report/report_name.py
+++ b/template/module/report/report_name.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright <YEAR(S)> <AUTHOR(S)>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 

--- a/template/module/tests/__init__.py
+++ b/template/module/tests/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import test_something

--- a/template/module/tests/test_abstract_something.py
+++ b/template/module/tests/test_abstract_something.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright <YEAR(S)> <AUTHOR(S)>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 

--- a/template/module/tests/test_something.py
+++ b/template/module/tests/test_something.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright <YEAR(S)> <AUTHOR(S)>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 

--- a/template/module/wizards/__init__.py
+++ b/template/module/wizards/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import wizard_model

--- a/template/module/wizards/wizard_model.py
+++ b/template/module/wizards/wizard_model.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright <YEAR(S)> <AUTHOR(S)>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 


### PR DESCRIPTION
### Milestone (Odoo version)

-  11.0 +

### New features

- UTF-8 as the default source encoding for Python 3.x.
