### PR TITLE
[FIX] gen_addon_readme.template: Avoid trailing whitespace

### DIFF
--- a/tests/data/readme_tests/addon1/README.expected-acme
+++ b/tests/data/readme_tests/addon1/README.expected-acme
@@ -14,7 +14,7 @@ addon 1
     :target: https://github.com/acme/server-tools/tree/12.0/addon1
     :alt: acme/server-tools
 
-|badge1| |badge2| 
+|badge1| |badge2|
 
 Some description
 

--- a/tests/data/readme_tests/addon1/README.expected-oca
+++ b/tests/data/readme_tests/addon1/README.expected-oca
@@ -20,7 +20,7 @@ addon 1
     :target: https://runbot.odoo-community.org/runbot/149/12.0
     :alt: Try me on Runbot
 
-|badge1| |badge2| |badge3| |badge4| 
+|badge1| |badge2| |badge3| |badge4|
 
 Some description
 

--- a/tests/data/readme_tests/addon_one_maintainer/README.expected-acme
+++ b/tests/data/readme_tests/addon_one_maintainer/README.expected-acme
@@ -14,7 +14,7 @@ addon one maintainer
     :target: https://github.com/acme/server-tools/tree/12.0/addon_one_maintainer
     :alt: acme/server-tools
 
-|badge1| |badge2| 
+|badge1| |badge2|
 
 Some description
 

--- a/tests/data/readme_tests/addon_one_maintainer/README.expected-oca
+++ b/tests/data/readme_tests/addon_one_maintainer/README.expected-oca
@@ -20,7 +20,7 @@ addon one maintainer
     :target: https://runbot.odoo-community.org/runbot/149/12.0
     :alt: Try me on Runbot
 
-|badge1| |badge2| |badge3| |badge4| 
+|badge1| |badge2| |badge3| |badge4|
 
 Some description
 

--- a/tests/data/readme_tests/addon_two_maintainers/README.expected-acme
+++ b/tests/data/readme_tests/addon_two_maintainers/README.expected-acme
@@ -14,7 +14,7 @@ addon one maintainer
     :target: https://github.com/acme/server-tools/tree/12.0/addon_two_maintainers
     :alt: acme/server-tools
 
-|badge1| |badge2| 
+|badge1| |badge2|
 
 Some description
 

--- a/tests/data/readme_tests/addon_two_maintainers/README.expected-oca
+++ b/tests/data/readme_tests/addon_two_maintainers/README.expected-oca
@@ -20,7 +20,7 @@ addon one maintainer
     :target: https://runbot.odoo-community.org/runbot/149/12.0
     :alt: Try me on Runbot
 
-|badge1| |badge2| |badge3| |badge4| 
+|badge1| |badge2| |badge3| |badge4|
 
 Some description
 

--- a/tools/gen_addon_readme.template
+++ b/tools/gen_addon_readme.template
@@ -23,7 +23,7 @@
     :alt: {{ alt }}
     {%- endif %}
 {% endfor %}
-{% for _ in badges %}|badge{{ loop.index }}| {% endfor %}
+{% for _ in badges %}|badge{{ loop.index }}|{% if loop.index != badges|length %} {% endif %}{% endfor %}
 
 {{ fragments.get('DESCRIPTION', '') }}
 {% if development_status == 'alpha' -%}


### PR DESCRIPTION
### Fixes
- Avoid the fucking trailing whitespace:

![Selection_111](https://user-images.githubusercontent.com/25005517/74459076-fb7dcb00-4e8a-11ea-89dd-965f624cd386.png)