### PR TITLE
gen-addons-table: do not fail if README.md is absent

### DIFF
--- a/tests/test_gen_addons_table.py
+++ b/tests/test_gen_addons_table.py
@@ -27,3 +27,11 @@ def test_1():
     finally:
         with open(readme_filename, 'w') as f:
             f.write(readme_before)
+
+
+def test_absent_readme(tmp_path):
+    """gen_addons_table must not fail if README.md is absent"""
+    res = subprocess.call([
+        sys.executable, "-m", "tools.gen_addons_table"
+    ], cwd=str(tmp_path))
+    assert res == 0

--- a/tools/gen_addons_table.py
+++ b/tools/gen_addons_table.py
@@ -90,7 +90,7 @@ def replace_in_readme(readme_path, header, rows_available, rows_unported):
 @click.option('--commit/--no-commit',
               help="git commit changes to README.rst, if any.")
 @click.option('--readme-path', default="README.md",
-              type=click.Path(dir_okay=False, file_okay=True, exists=True),
+              type=click.Path(dir_okay=False, file_okay=True),
               help="README.md file with addon table markers")
 @click.option('--addons-dir', default=".",
               type=click.Path(dir_okay=True, file_okay=False, exists=True),


### PR DESCRIPTION
There is a warning foreseen in that case.

Regression was introduced in #436 