### PR TITLE
[ADD] pre-commit hook to exclude not installable addons

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -18,3 +18,11 @@
   entry: oca-gen-addon-icon
   language: python
   pass_filenames: false
+
+- id: oca-update-pre-commit-excluded-addons
+  name: update pre-commit excluded addons
+  entry: oca-update-pre-commit-excluded-addons
+  pass_filenames: false
+  language: python
+  types: [python]
+  files: /(__manifest__|__openerp__|__terp__|)\.py$

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,8 @@ setuptools.setup(
             'oca-gen-addon-icon = tools.gen_addon_icon:gen_addon_icon',
             'oca-towncrier = tools.oca_towncrier:oca_towncrier',
             'oca-create-migration-issue = tools.create_migration_issue:main',
+            'oca-update-pre-commit-excluded-addons = '
+            'tools.update_pre_commit_excluded_addons:main',
         ],
     },
 )

--- a/tests/test_update_pre_commit_excluded_addons.py
+++ b/tests/test_update_pre_commit_excluded_addons.py
@@ -1,0 +1,128 @@
+from __future__ import unicode_literals
+import subprocess
+import textwrap
+
+
+def test_update_pre_commit_excluded_addons(tmp_path):
+    pre_commit = tmp_path / ".pre-commit-config.yaml"
+    pre_commit.write_text(
+        textwrap.dedent(
+            """\
+                exclude: |
+                  (?x)
+                  # NOT INSTALLABLE ADDONS
+                  # END NOT INSTALLABLE ADDONS
+                  tail_exclude
+                default_language_version:
+                  python: python3
+            """
+        )
+    )
+    addon1 = tmp_path / "addon1"
+    addon1.mkdir()
+    m1 = addon1 / "__manifest__.py"
+    addon2 = tmp_path / "addon2"
+    addon2.mkdir()
+    m2 = addon2 / "__manifest__.py"
+    addon3 = tmp_path / "addon3"
+    addon3.mkdir()
+    m3 = addon3 / "__manifest__.py"
+    # addon1 and addon2 installable
+    m1.write_text("{}")
+    m2.write_text("{}")
+    m3.write_text("{}")
+    subprocess.check_call(["oca-update-pre-commit-excluded-addons"], cwd=str(tmp_path))
+    assert pre_commit.read_text() == textwrap.dedent(
+        """\
+            exclude: |
+              (?x)
+              # NOT INSTALLABLE ADDONS
+              # END NOT INSTALLABLE ADDONS
+              tail_exclude
+            default_language_version:
+              python: python3
+        """
+    )
+    # addon1 installable and addon2 not installable
+    m2.write_text("{'installable': False}")
+    subprocess.check_call(["oca-update-pre-commit-excluded-addons"], cwd=str(tmp_path))
+    assert pre_commit.read_text() == textwrap.dedent(
+        """\
+            exclude: |
+              (?x)
+              # NOT INSTALLABLE ADDONS
+              ^addon2/|
+              # END NOT INSTALLABLE ADDONS
+              tail_exclude
+            default_language_version:
+              python: python3
+        """
+    )
+    # addon1 installable and addon2, addon3 not installable
+    m3.write_text("{'installable': False}")
+    subprocess.check_call(["oca-update-pre-commit-excluded-addons"], cwd=str(tmp_path))
+    assert pre_commit.read_text() == textwrap.dedent(
+        """\
+            exclude: |
+              (?x)
+              # NOT INSTALLABLE ADDONS
+              ^addon2/|
+              ^addon3/|
+              # END NOT INSTALLABLE ADDONS
+              tail_exclude
+            default_language_version:
+              python: python3
+        """
+    )
+
+
+def test_update_pre_commit_excluded_addons_subdir(tmp_path):
+    pre_commit = tmp_path / ".pre-commit-config.yaml"
+    pre_commit.write_text(
+        textwrap.dedent(
+            """\
+                exclude: |
+                  (?x)
+                  # NOT INSTALLABLE ADDONS
+                  # END NOT INSTALLABLE ADDONS
+                  tail_exclude
+                default_language_version:
+                  python: python3
+            """
+        )
+    )
+    addon1 = tmp_path / "odoo" / "addons" / "addon1"
+    addon1.mkdir(parents=True)
+    m1 = addon1 / "__manifest__.py"
+    # addon1 installable
+    m1.write_text("{}")
+    subprocess.check_call(["oca-update-pre-commit-excluded-addons"], cwd=str(tmp_path))
+    assert pre_commit.read_text() == textwrap.dedent(
+        """\
+            exclude: |
+              (?x)
+              # NOT INSTALLABLE ADDONS
+              # END NOT INSTALLABLE ADDONS
+              tail_exclude
+            default_language_version:
+              python: python3
+        """
+    )
+    # addon1 not installable
+    m1.write_text("{'installable': False}")
+    subprocess.check_call(
+        ["oca-update-pre-commit-excluded-addons", "--addons-dir", "odoo/addons"],
+        cwd=str(tmp_path),
+    )
+    assert pre_commit.read_text() == textwrap.dedent(
+        """\
+            exclude: |
+              (?x)
+              # NOT INSTALLABLE ADDONS
+              ^odoo/addons/addon1/|
+              # END NOT INSTALLABLE ADDONS
+              tail_exclude
+            default_language_version:
+              python: python3
+        """
+    )

--- a/tools/update_pre_commit_excluded_addons.py
+++ b/tools/update_pre_commit_excluded_addons.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+import ast
+import os
+
+import click
+
+PRE_COMMIT_FILE_PATH = ".pre-commit-config.yaml"
+PRE_COMMIT_EXCLUDE_SEPARATOR = "# NOT INSTALLABLE ADDONS"
+PRE_COMMIT_EXCLUDE_SEPARATOR_END = "# END NOT INSTALLABLE ADDONS"
+
+MANIFEST_NAMES = ("__manifest__.py", "__openerp__.py", "__terp__.py")
+
+
+class NoManifestFound(Exception):
+    pass
+
+
+def get_manifest_path(addon_dir):
+    for manifest_name in MANIFEST_NAMES:
+        manifest_path = os.path.join(addon_dir, manifest_name)
+        if os.path.isfile(manifest_path):
+            return manifest_path
+
+
+def parse_manifest(s):
+    return ast.literal_eval(s)
+
+
+def read_manifest(addon_dir):
+    manifest_path = get_manifest_path(addon_dir)
+    if not manifest_path:
+        raise NoManifestFound("no Odoo manifest found in %s" % addon_dir)
+    with open(manifest_path) as mf:
+        return parse_manifest(mf.read())
+
+
+def is_not_installable_addon(addon_dir):
+    try:
+        manifest = read_manifest(addon_dir)
+    except NoManifestFound:
+        return False
+    return not manifest.get("installable", True)
+
+
+@click.command()
+@click.option("--addons-dir", default="")
+def main(addons_dir):
+    """ Update .pre-commit-config.yaml exclude section with the list of
+        uninstallable addons. The section must begin with a line
+        containing '# NOT INSTALLABLE ADDONS' and end with a line
+        containing '# END NOT INSTALLABLE ADDONS'.
+    """
+    not_installable_addons = []
+    addons = os.listdir(addons_dir or ".")
+    for addon in addons:
+        addon_dir = os.path.join(addons_dir, addon)
+        if is_not_installable_addon(addon_dir):
+            exclude_addon = "  ^{addon_dir}/".format(addon_dir=addon_dir)
+            not_installable_addons.append(exclude_addon)
+    not_installable_addons.sort()
+    not_installable_addons_pre_commit = "|\n".join(not_installable_addons)
+    if not_installable_addons_pre_commit:
+        not_installable_addons_pre_commit += "|\n"
+    replace_on = False
+    with open(PRE_COMMIT_FILE_PATH, "r+") as pre_commit_file:
+        pre_commit_file_lines = pre_commit_file.readlines()
+        pre_commit_file.seek(0)
+        for line in pre_commit_file_lines:
+            if PRE_COMMIT_EXCLUDE_SEPARATOR_END in line:
+                replace_on = False
+            if replace_on:
+                continue
+            if PRE_COMMIT_EXCLUDE_SEPARATOR in line:
+                replace_on = True
+                pre_commit_file.write(line)
+                pre_commit_file.write(not_installable_addons_pre_commit)
+                continue
+            pre_commit_file.write(line)
+        pre_commit_file.truncate()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
In repos with `installable=False` addons it is useful to exclude these from the pre-commit checks.

This PR provides a pre-commit hook that updates `.pre-commit-config.yaml` with the exclude list, making sure the exclude list remains up-to-date.

Typical usage in https://github.com/OCA/oca-addons-repo-template/pull/3