### PR TITLE
Improvements of tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,23 @@ install:
     - pip install tox-travis
     - pip install coveralls
 
+# stages:
+#  - linting
+#  - test
+#  - test-ocb
+
+#jobs:
+#  include:
+#    - stage: linting
+#      env:
+#        - LINT_CHECK="1"
+#    - stage: test
+#      env:
+#        - TESTS="1" ODOO_REPO="odoo/odoo"
+#    - stage: test-ocb
+#      env:
+#        - TESTS="1" ODOO_REPO="OCA/OCB"
+
 script:
     - tox
 


### PR DESCRIPTION
In order to avoid too much travis jobs (and getting slow on other repos), I propose to set three steps for tests. The advantage is that the folowing ones are not running if preceding ones are failing.

One for 'lint', one for odoo based tests and one for OCB based ones (if odoo tests are failing, there is no reason of running OCB ones)

@sbidoul @pedrobaeza 