### PR TITLE
Add pipx method to installation methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@
     $ virtualenv env
     $ . env/bin/activate
     $ python setup.py install
+    
+Alternatively if using pipx.
+    
+    $ git clone git@github.com:OCA/maintainer-tools.git
+    $ pipx install ./maintainer-tools
 
 ## OCA repositories tools
 


### PR DESCRIPTION
Current installation method refers to using virtualenv, but with pipx gaining in popularity we should add pipx install instructions.
