### PR TITLE
always run oca-update-pre-commit-excluded-addons hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -24,5 +24,4 @@
   entry: oca-update-pre-commit-excluded-addons
   pass_filenames: false
   language: python
-  types: [python]
-  files: /(__manifest__|__openerp__|__terp__|)\.py$
+  always_run: true


### PR DESCRIPTION
Before this patch, the hook would not run if an excluded addon (because installable=False) was flipped to installable=True.