### PR TITLE
[ADD] oca-fix-manifest-website

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -20,8 +20,15 @@
   pass_filenames: false
 
 - id: oca-update-pre-commit-excluded-addons
-  name: update pre-commit excluded addons
+  name: Update pre-commit excluded addons
   entry: oca-update-pre-commit-excluded-addons
   pass_filenames: false
   language: python
   always_run: true
+
+- id: oca-fix-manifest-website
+  name: Fix the manifest website key
+  entry: oca-fix-manifest-website
+  pass_filenames: false
+  language: python
+  files: (__manifest__\.py|__openerp__\.py|__terp__\.py)$

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setuptools.setup(
             'oca-create-migration-issue = tools.create_migration_issue:main',
             'oca-update-pre-commit-excluded-addons = '
             'tools.update_pre_commit_excluded_addons:main',
+            'oca-fix-manifest-website = tools.fix_manifest_website:main',
         ],
     },
 )

--- a/tests/test_fix_manifest_website.py
+++ b/tests/test_fix_manifest_website.py
@@ -1,0 +1,24 @@
+from tools.fix_manifest_website import main
+
+from click.testing import CliRunner
+
+
+def test_fix_manifest_website(tmp_path):
+    (tmp_path / "a1").mkdir()
+    (tmp_path / "a1" / "__manifest__.py").write_text(
+        """{'name': 'a1', 'website': '...'}"""
+    )
+    (tmp_path / "a2").mkdir()
+    (tmp_path / "a2" / "__manifest__.py").write_text(
+        """{'name': 'a2', "website"   :\n "https://bad.url"}"""
+    )
+    result = CliRunner().invoke(
+        main, ["--addons-dir", str(tmp_path), "https://new.url"]
+    )
+    assert result.exit_code == 0
+    assert (
+        tmp_path / "a1" / "__manifest__.py"
+    ).read_text() == """{'name': 'a1', 'website': 'https://new.url'}"""
+    assert (
+        tmp_path / "a2" / "__manifest__.py"
+    ).read_text() == """{'name': 'a2', "website"   :\n "https://new.url"}"""

--- a/tools/fix_manifest_website.py
+++ b/tools/fix_manifest_website.py
@@ -1,0 +1,47 @@
+"""Set the website key in addons manifests."""
+import os
+import re
+
+import click
+
+from .manifest import get_manifest_path, parse_manifest
+
+
+WEBSITE_KEY_RE = re.compile(r"""(["']website["']\s*:\s*["'])([^"']*)(["'])""")
+
+
+@click.command()
+@click.argument("url")
+@click.option("--addons-dir", default=".")
+def main(url, addons_dir):
+    for addon_dir in os.listdir(addons_dir):
+        manifest_path = get_manifest_path(os.path.join(addons_dir, addon_dir))
+        if not manifest_path:
+            continue
+        try:
+            with open(manifest_path) as manifest_file:
+                manifest = parse_manifest(manifest_file.read())
+        except Exception:
+            raise click.ClickException(
+                "Error parsing manifest {}.".format(manifest_path)
+            )
+        if "website" not in manifest:
+            raise click.ClickException(
+                "website key not found in manifest in {}.".format(addon_dir)
+            )
+        with open(manifest_path) as manifest_file:
+            manifest_str = manifest_file.read()
+        new_manifest_str, n = WEBSITE_KEY_RE.subn(
+            r"\g<1>" + url + r"\g<3>", manifest_str
+        )
+        if n == 0:
+            raise click.ClickException(
+                "no website key match in manifest in {}.".format(addon_dir)
+            )
+        if n > 1:
+            raise click.ClickException(
+                "more than one website key match in manifest in {}.".format(addon_dir)
+            )
+        if new_manifest_str != manifest_str:
+            with open(manifest_path, "w") as manifest_file:
+                manifest_file.write(new_manifest_str)


### PR DESCRIPTION
Setting a wrong website key in manifest is a common error that is currently not reported to contributors.

This `oca-fix-manifest-website` script is intended to be added in a pre-commit hook.