### PR TITLE
[ADD] oca-copier-update

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setuptools.setup(
             'oca-fix-manifest-website = tools.fix_manifest_website:main',
             'oca-configure-travis= tools.configure_travis:main',
             'oca-create-branch = tools.create_branch:main',
+            'oca-copier-update = tools.copier_update:main',
         ],
     },
 )

--- a/tools/copier_update.py
+++ b/tools/copier_update.py
@@ -99,8 +99,8 @@ def _iterate_repos_and_branches(repos: str, branches: str) -> Iterable[Tuple[str
 @click.option("--org", default="OCA")
 @click.option("--repos", required=True)
 @click.option("--branches", required=True)
-@click.option("--git-user-name")
-@click.option("--git-user-email")
+@click.option("--git-user-name", default="oca-git-bot")
+@click.option("--git-user-email", default="oca-git-bot@odoo-community.org")
 @click.option("--skip-ci/--no-skip-ci", default=False)
 def main(
     org: str,

--- a/tools/copier_update.py
+++ b/tools/copier_update.py
@@ -15,7 +15,7 @@ from .oca_projects import BranchNotFoundError, get_repositories, temporary_clone
 ORG = "OCA"
 
 
-def _make_update_dotfiles_branch(branch):
+def _make_update_dotfiles_branch(branch: str) -> str:
     return f"{branch}-ocabot-update-dotfiles"
 
 
@@ -82,10 +82,8 @@ def _make_update_dotfiles_pr(org: str, repo: str, branch: str) -> None:
 
 @click.command()
 @click.argument("branch")
-def main(branch):
+def main(branch: str) -> None:
     for repo in get_repositories():
-        if repo not in ("event",):
-            continue
         try:
             with temporary_clone(repo, branch):
                 print("=" * 10, repo, "=" * 10)
@@ -106,7 +104,9 @@ def main(branch):
                 # git add updated files so pre-commit run -a will pick them up
                 # (notably newly created .rej files)
                 subprocess.check_call(["git", "add", "."])
-                # run up to 3 pre-commit passes, in case fixes cause
+                # run up to 3 pre-commit passes, in case autofixers
+                # (which cause pre-commit to fail when they change files)
+                # resolve issues
                 for _ in range(3):
                     r = subprocess.call(["pre-commit", "run", "-a"])
                     # git add, in case pre-commit created new files

--- a/tools/copier_update.py
+++ b/tools/copier_update.py
@@ -1,0 +1,102 @@
+"""Run copier update on a branch in all addons repos.
+"""
+from pathlib import Path
+import os
+import subprocess
+from typing import Optional
+
+import click
+import requests
+
+from .gitutils import commit_if_needed
+from .oca_projects import BranchNotFoundError, get_repositories, temporary_clone
+
+
+def _make_update_dotfiles_branch(branch):
+    return f"{branch}-update-dotfiles"
+
+
+def _make_commit_msg(ci_skip: bool) -> str:
+    msg = "[IMP] update dotfiles"
+    if ci_skip:
+        msg += " [ci skip]"
+    return msg
+
+
+def _has_rej_file() -> bool:
+    for _, _, filenames in os.walk("."):
+        if any(f.endswith(".rej") for f in filenames):
+            return True
+    return False
+
+
+def _get_update_dotfiles_open_pr(repo: str, branch: str) -> Optional[str]:
+    r = requests.get(
+        f"https://api.github.com/repos"
+        f"/OCA/{repo}/pulls"
+        f"?base={branch}&head=OCA:{_make_update_dotfiles_branch(branch)}"
+    )
+    r.raise_for_status()
+    pr = r.json()
+    if pr["state"] == "open":
+        return pr["number"]
+    return None
+
+
+def _make_update_dotfiles_pr(repo: str, branch: str) -> None:
+    subprocess.check_call(
+        ["git", "checkout", "-B", _make_update_dotfiles_branch(branch)]
+    )
+    subprocess.check_call(["git", "add", "."])
+    subprocess.check_call(["git", "commit", "-m", _make_commit_msg(ci_skip=False)])
+    subprocess.check_call(["git", "push"])
+    # TODO create PR
+
+
+@click.command()
+@click.argument("branch")
+def main(branch):
+    for repo in get_repositories():
+        try:
+            with temporary_clone(repo, branch):
+                print("=" * 10, repo, "=" * 10)
+                # set git user/email
+                subprocess.check_call(
+                    ["git", "config", "user.name", "oca-git-bot"],
+                )
+                subprocess.check_call(
+                    ["git", "config", "user.email", "oca-git-bot@odoo-community.org"],
+                )
+                if not Path(".copier-answers.yml").exists():
+                    print(f"Skipping {repo} because it has no .copier-answers.yml")
+                    continue
+                r = subprocess.call(
+                    [
+                        "copier",
+                        "-f",
+                        # !!!
+                        "-d",
+                        "generate_requirements_txt=yes",
+                        # !!!
+                        "update",
+                    ]
+                )
+                if r != 0:
+                    print("!" * 10, f"copier update failed on {repo}")
+                    continue
+                if _has_rej_file():
+                    print("!" * 10, f"copier update had a merge failure on {repo}")
+                    # TODO create or update update-dotfiles PR
+                    continue
+                for _ in range(3):
+                    r = subprocess.call(["pre-commit", "run", "-a"])
+                    if r == 0:
+                        break
+                if r != 0:
+                    print("!" * 10, f"pre-commit failed on {repo}")
+                    # TODO create or update update-dotfiles PR
+                    continue
+                if commit_if_needed(["."], _make_commit_msg(ci_skip=True)):
+                    subprocess.check_call(["git", "push"])
+        except BranchNotFoundError:
+            pass

--- a/tools/github_login.py
+++ b/tools/github_login.py
@@ -10,6 +10,10 @@ import github3
 from .config import read_config, write_config
 
 
+class GitHubLoginError(RuntimeError):
+    pass
+
+
 def login():
     if os.environ.get('GITHUB_TOKEN'):
         token = os.environ['GITHUB_TOKEN']
@@ -17,9 +21,11 @@ def login():
         config = read_config()
         token = config.get('GitHub', 'token')
     if not token:
-        sys.exit("No token has been generated for this script. "
-                 "Please run 'oca-github-login' or set the GITHUB_TOKEN "
-                 "environment variable.")
+        raise GitHubLoginError(
+            "No token has been generated for this script. "
+            "Please run 'oca-github-login' or set the GITHUB_TOKEN "
+            "environment variable."
+        )
     return github3.login(token=token)
 
 

--- a/tools/oca_projects.py
+++ b/tools/oca_projects.py
@@ -253,8 +253,6 @@ _URL_MAPPINGS = {'git': 'git@github.com:%s/%s.git',
 
 def url(project_name, protocol='git', org_name='OCA'):
     """get the URL for an OCA project repository"""
-    if project_name not in _OCA_REPOSITORY_NAMES:
-        raise ValueError('Unknown project', project_name)
     return _URL_MAPPINGS[protocol] % (org_name, project_name)
 
 


### PR DESCRIPTION
This is the script I currently use to update dotfiles. I post it here in draft state case anyone is interested.

Needs thinking:
- This should probably be a bot action
- It runs pre-commit locally. If ok, it pushes to the main branch with [ci skip]. If not it creates a PR ([example](https://github.com/OCA/event/pull/200)). This is a shortcut to save CI build time, but in the general case, a dotfiles update could break something else than pre-commit. So it might be best to always create a PR and immediately ocabot merge it. The drawback is that it will create a ci build storm...
- Also, running pre-commit locally might have security implications
- Yet, it is currently necessary to autoformat copier-generated files (e.g. yaml files)
