### PR TITLE
[FIX] Force egg extraction otherwise templates are not available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setuptools.setup(
     license='APGL3',
     packages=['tools'],
     include_package_data=True,
+    zip_safe=False,
     use_scm_version=True,
     setup_requires=[
         'setuptools_scm',


### PR DESCRIPTION
By following the installation README, I got the case where a pip install (pip 20.1.1) created an egg zip file instead of an egg folder.
So any tools expecting to find an egg folder (with templates inside) just fails.

The `zip_safe=False` parameter force the extraction to an egg folder.

