### PR TITLE
copy_maintainer: fix invite

### DIFF
--- a/tools/copy_maintainers.py
+++ b/tools/copy_maintainers.py
@@ -233,7 +233,7 @@ def sync_team(team, logins, dry_run=False):
     if not dry_run:
         for login in add_logins:
             try:
-                team.invite(login)
+                team.add_or_update_membership(login)
             except Exception as exc:
                 print('Failed to invite %s: %s' % (login, exc))
         for login in remove_logins:


### PR DESCRIPTION
The invite method does not exist in github3.py version 2.0
