### PR TITLE
[FIX] pipx install (into readme)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@
 
 Alternatively if using pipx.
 
-    $ git clone git@github.com:OCA/maintainer-tools.git
-    $ pipx install ./maintainer-tools
+    $ pipx install oca-maintainers-tools@git+https://github.com/OCA/maintainer-tools.git
 
 ## OCA repositories tools
 


### PR DESCRIPTION
### Milestone (Odoo version)
- NA

### Module(s)
- NA

### Fixes / new features
- The command line (into readme) to install maintainers-tools with `pipx` doesn't work.
- Fix: update command line
