### PR TITLE
[IMP][RFC] oca-gen-addons-table : add developpement_status badge.

### DIFF
--- a/tests/test_repo/README.md.expected
+++ b/tests/test_repo/README.md.expected
@@ -11,17 +11,17 @@ ${REPO_DESCRIPTION}
 
 Available addons
 ----------------
-addon | version | summary
---- | --- | ---
-[module1](module1/) | 8.0.1.0.0 | Module 1 summary
+addon | version | maintainers | summary
+--- | --- | --- | ---
+[module1](module1/) | 8.0.1.0.0 [![Production/Stable](https://img.shields.io/badge/maturity-Production%2FStable-green.png)](https://odoo-community.org/page/development-status) | [![sbidoul](https://github.com/sbidoul.png?size=30px)](https://github.com/sbidoul) | Module 1 summary
 
 
 Unported addons
 ---------------
-addon | version | summary
---- | --- | ---
-[module3](__unported__/module3/) | 8.0.1.0.0 (unported) | Module 3 summary
-[module2](module2/) | 8.0.1.0.0 (unported) | Module 2 summary
+addon | version | maintainers | summary
+--- | --- | --- | ---
+[module3](__unported__/module3/) | 8.0.1.0.0 (unported) [![Beta](https://img.shields.io/badge/maturity-Beta-yellow.png)](https://odoo-community.org/page/development-status) | | Module 3 summary
+[module2](module2/) | 8.0.1.0.0 (unported) [![Beta](https://img.shields.io/badge/maturity-Beta-yellow.png)](https://odoo-community.org/page/development-status) | | Module 2 summary
 
 [//]: # (end addons)
 

--- a/tests/test_repo/module1/__openerp__.py
+++ b/tests/test_repo/module1/__openerp__.py
@@ -8,6 +8,8 @@
     "category": "Uncategorized",
     "website": "https://odoo-community.org/",
     "author": "<AUTHOR(S)>, Odoo Community Association (OCA)",
+    "maintainers": ["sbidoul"],
+    "development_status": "Production/Stable",
     "license": "AGPL-3",
     "application": False,
     "installable": True,

--- a/tools/gen_addons_table.py
+++ b/tools/gen_addons_table.py
@@ -156,7 +156,7 @@ def gen_addons_table(commit, readme_path, addons_dir):
             if installable:
                 rows_available.append((
                     link,
-                    version + render_status(manifest),
+                    version + " " + render_status(manifest),
                     render_maintainers(manifest),
                     summary))
             else:


### PR DESCRIPTION
- Add maintainers column in the readme file of the repository.

The inserted image contains the following code 
``[![MAINTAINER](https://github.com/MAINTAINER.png?size=30px)](https://github.com/MAINTAINER)``

- Add maturity badge in version column. 

**Result for the OCA/pos repository :**

![image](https://user-images.githubusercontent.com/3407482/127755759-f0fad222-190b-4d68-8d75-3b38e2f66a59.png)


Full result : https://github.com/legalsylvain/pos/tree/12.0-TEST-oca-gen-addons-table-maintainers

Thanks for your review.

CC : original author / commiter of this file : @sbidoul, @StefanRijnhart.
CC : @quentinDupont 

Closes: #454