### PR TITLE
[IMP] add maintainers column in addons table. #454

### DIFF
--- a/tests/test_repo/README.md.expected
+++ b/tests/test_repo/README.md.expected
@@ -11,17 +11,17 @@ ${REPO_DESCRIPTION}
 
 Available addons
 ----------------
-addon | version | summary
---- | --- | ---
-[module1](module1/) | 8.0.1.0.0 | Module 1 summary
+addon | version | maintainers | summary
+--- | --- | --- | ---
+[module1](module1/) | 8.0.1.0.0 | [![sbidoul](https://github.com/sbidoul.png?size=30px)](https://github.com/sbidoul) | Module 1 summary
 
 
 Unported addons
 ---------------
-addon | version | summary
---- | --- | ---
-[module3](__unported__/module3/) | 8.0.1.0.0 (unported) | Module 3 summary
-[module2](module2/) | 8.0.1.0.0 (unported) | Module 2 summary
+addon | version | maintainers | summary
+--- | --- | --- | ---
+[module3](__unported__/module3/) | 8.0.1.0.0 (unported) |  | Module 3 summary
+[module2](module2/) | 8.0.1.0.0 (unported) |  | Module 2 summary
 
 [//]: # (end addons)
 

--- a/tests/test_repo/module1/__openerp__.py
+++ b/tests/test_repo/module1/__openerp__.py
@@ -8,6 +8,7 @@
     "category": "Uncategorized",
     "website": "https://odoo-community.org/",
     "author": "<AUTHOR(S)>, Odoo Community Association (OCA)",
+    "maintainers": ["sbidoul"],
     "license": "AGPL-3",
     "application": False,
     "installable": True,

--- a/tools/gen_addons_table.py
+++ b/tools/gen_addons_table.py
@@ -50,6 +50,15 @@ def render_markdown_table(header, rows):
     return '\n'.join(table)
 
 
+def render_maintainers(manifest):
+    maintainers = manifest.get('maintainers') or []
+    return " ".join([
+        "[![{maintainer}]"
+        "(https://github.com/{maintainer}.png?size=30px)]"
+        "(https://github.com/{maintainer})".format(maintainer=x)
+        for x in maintainers])
+
+
 def replace_in_readme(readme_path, header, rows_available, rows_unported):
     with io.open(readme_path, encoding='utf8') as f:
         readme = f.read()
@@ -111,7 +120,7 @@ def gen_addons_table(commit, readme_path, addons_dir):
             addon_paths.append((addon_path, True))
     addon_paths = sorted(addon_paths, key=lambda x: x[0])
     # load manifests
-    header = ('addon', 'version', 'summary')
+    header = ('addon', 'version', 'maintainers', 'summary')
     rows_available = []
     rows_unported = []
     for addon_path, unported in addon_paths:
@@ -134,9 +143,18 @@ def gen_addons_table(commit, readme_path, addons_dir):
                                 'installable.' % addon_path)
                 installable = False
             if installable:
-                rows_available.append((link, version, summary))
+                rows_available.append((
+                    link,
+                    version,
+                    render_maintainers(manifest),
+                    summary))
             else:
-                rows_unported.append((link, version + ' (unported)', summary))
+                rows_unported.append((
+                    link,
+                    version + ' (unported)',
+                    render_maintainers(manifest),
+                    summary
+                ))
     # replace table in README.md
     replace_in_readme(readme_path, header, rows_available, rows_unported)
     if commit:


### PR DESCRIPTION
supersed #505
partial close : #454

Add maintainers column in the readme file of the repository.

The inserted image contains the following code
[![MAINTAINER](https://github.com/MAINTAINER.png?size=30px)](https://github.com/MAINTAINER)

Partial result

![image](https://user-images.githubusercontent.com/3407482/127839114-6d7f0d4d-4ee3-40a5-a35c-80ace9fa396a.png)

See full result : https://github.com/legalsylvain/pos/tree/12.0-TEST-oca-gen-addons-table-maintainers#readme

Thanks for your review.

CC : @sbidoul, rousseldenis
CC : @quentinDupont