### PR TITLE
copy_maintainers: remove deprecated create_team arg

### DIFF
--- a/tools/copy_maintainers.py
+++ b/tools/copy_maintainers.py
@@ -107,8 +107,7 @@ class GHTeamList(object):
         if not self.dry_run:
             self._org.create_team(
                 name=team_name,
-                repo_names=repo_names,
-                permission='admin')
+                repo_names=repo_names)
         self._load_teams()
         return self._teams.get(team_name)
 


### PR DESCRIPTION
The permission argument is deprecated in the GitHub API and was causing errors.
