### PR TITLE
[IMP] adapt to work on Python3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.8", "3.10"]
+        python-version: ["3.6", "3.8", "3.10", "3.11"]
     steps:
       - uses: "actions/checkout@v2"
       - uses: "actions/setup-python@v2"

--- a/tools/gen_addon_readme.py
+++ b/tools/gen_addon_readme.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2018 ACSONE SA/NV
 # Copyright (c) 2018 GRAP (http://www.grap.coop)
 
-import io
 import os
 import re
 import sys
@@ -179,7 +178,7 @@ def gen_one_addon_readme(
             addon_dir, FRAGMENTS_DIR, fragment_name + '.rst',
         )
         if os.path.exists(fragment_filename):
-            with io.open(fragment_filename, 'rU', encoding='utf8') as f:
+            with open(fragment_filename, 'r', encoding='utf8') as f:
                 fragment = generate_fragment(
                     org_name, repo_name, branch, addon_name, f)
                 if fragment:
@@ -210,9 +209,9 @@ def gen_one_addon_readme(
         os.path.join(os.path.dirname(__file__), 'gen_addon_readme.template')
     readme_filename = \
         os.path.join(addon_dir, 'README.rst')
-    with io.open(template_filename, 'rU', encoding='utf8') as tf:
+    with open(template_filename, 'r', encoding='utf8') as tf:
         template = Template(tf.read())
-    with io.open(readme_filename, 'w', encoding='utf8') as rf:
+    with open(readme_filename, 'w', encoding='utf8') as rf:
         rf.write(template.render(
             addon_name=addon_name,
             authors=authors,

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist =
     py38
     py39
     py310
+    py311
 
 [testenv]
 skip_missing_interpreters = True
@@ -24,3 +25,4 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311


### PR DESCRIPTION
Python3.11 no longer works with Universal newline in file read mode, as it is used by default from 3.3

### Milestone (Odoo version)
- 

### Module(s)
- 

### Fixes / new features
- Adapts the oca-gen-addon-readme to work with Python3.11. As you can see in https://docs.python.org/3.11/whatsnew/3.11.html
Universal file read mode flag is no longer supporte as it is the default after python 3.3
