### PR TITLE
gen-addon-readme: use the canonical URL for runboat builds

### DIFF
--- a/tests/data/readme_tests/addon1/README.expected-oca
+++ b/tests/data/readme_tests/addon1/README.expected-oca
@@ -20,7 +20,7 @@ addon 1
     :target: https://translation.odoo-community.org/projects/server-tools-12-0/server-tools-12-0-addon1
     :alt: Translate me on Weblate
 .. |badge4| image:: https://img.shields.io/badge/runboat-Try%20me-875A7B.png
-    :target: https://runboat.odoo-community.org/webui/builds.html?repo=OCA/server-tools&target_branch=12.0
+    :target: https://runboat.odoo-community.org/builds?repo=OCA/server-tools&target_branch=12.0
     :alt: Try me on Runboat
 
 |badge1| |badge2| |badge3| |badge4|

--- a/tests/data/readme_tests/addon_one_maintainer/README.expected-oca
+++ b/tests/data/readme_tests/addon_one_maintainer/README.expected-oca
@@ -20,7 +20,7 @@ addon one maintainer
     :target: https://translation.odoo-community.org/projects/server-tools-12-0/server-tools-12-0-addon_one_maintainer
     :alt: Translate me on Weblate
 .. |badge4| image:: https://img.shields.io/badge/runboat-Try%20me-875A7B.png
-    :target: https://runboat.odoo-community.org/webui/builds.html?repo=OCA/server-tools&target_branch=12.0
+    :target: https://runboat.odoo-community.org/builds?repo=OCA/server-tools&target_branch=12.0
     :alt: Try me on Runboat
 
 |badge1| |badge2| |badge3| |badge4|

--- a/tests/data/readme_tests/addon_two_maintainers/README.expected-oca
+++ b/tests/data/readme_tests/addon_two_maintainers/README.expected-oca
@@ -20,7 +20,7 @@ addon one maintainer
     :target: https://translation.odoo-community.org/projects/server-tools-12-0/server-tools-12-0-addon_two_maintainers
     :alt: Translate me on Weblate
 .. |badge4| image:: https://img.shields.io/badge/runboat-Try%20me-875A7B.png
-    :target: https://runboat.odoo-community.org/webui/builds.html?repo=OCA/server-tools&target_branch=12.0
+    :target: https://runboat.odoo-community.org/builds?repo=OCA/server-tools&target_branch=12.0
     :alt: Try me on Runboat
 
 |badge1| |badge2| |badge3| |badge4|

--- a/tools/gen_addon_readme.py
+++ b/tools/gen_addon_readme.py
@@ -105,7 +105,7 @@ RST2HTML_SETTINGS = {
 def make_runboat_badge(repo, branch):
     return (
         "https://img.shields.io/badge/runboat-Try%20me-875A7B.png",
-        "https://runboat.odoo-community.org/webui/builds.html?"
+        "https://runboat.odoo-community.org/builds?"
         "repo=OCA/{repo}&target_branch={branch}".format(**locals()),
         "Try me on Runboat",
     )


### PR DESCRIPTION
The other URL is an implementation detail of the current UI.
