### PR TITLE
Unpin docutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,7 @@ setuptools.setup(
     install_requires=[
         "appdirs",
         "click",
-        # We need to pin docutils version, see
-        # https://github.com/OCA/maintainer-tools/issues/423
-        # Consider carefully before changing this.
-        "docutils==0.16.*",
+        "docutils",
         "pypandoc",  # for oca-gen-addon-readme to work with markdown fragments
         "ERPpeek",
         "github3.py>=1",


### PR DESCRIPTION
Since we now have `oca-gen-addon-readme --if-fragment-changed` which we will deploy to the OCA bot and pre-commit we can unpin docutils.

closes #423 
towards #564 