### PR TITLE
[FIX] do not use MAIN_BRANCHES anymore

### DIFF
--- a/tools/config.py
+++ b/tools/config.py
@@ -69,21 +69,5 @@ NOT_ADDONS = {
 }
 
 
-# deprecated, use is_main_branch() instead
-MAIN_BRANCHES = (
-    "6.1",
-    "7.0",
-    "8.0",
-    "9.0",
-    "10.0",
-    "11.0",
-    "12.0",
-    "13.0",
-    "14.0",
-    "15.0",
-    "16.0",
-)
-
-
 def is_main_branch(branch):
     return re.match(r"^(6\.1|\d+\.0)$", branch)

--- a/tools/oca_projects.py
+++ b/tools/oca_projects.py
@@ -18,7 +18,7 @@ import subprocess
 import tempfile
 
 import appdirs
-from .config import MAIN_BRANCHES, NOT_ADDONS
+from .config import NOT_ADDONS, is_main_branch
 from .github_login import login
 
 ALL = ["OCA_PROJECTS", "OCA_REPOSITORY_NAMES", "url"]
@@ -234,7 +234,7 @@ def get_repositories():
     return all_repos
 
 
-def get_repositories_and_branches(repos=(), branches=MAIN_BRANCHES, branch_filter=None):
+def get_repositories_and_branches(repos=(), branches=(), branch_filter=is_main_branch):
     gh = login()
     for repo in gh.repositories_by("OCA"):
         if repos and repo.name not in repos:


### PR DESCRIPTION
### Fixes
This PR tends to fix the issue that 17.0 branch are not taken into account by oca_projects.py get_repositories_and_branches function causing for instance that these are not created in Weblate (see https://odoo-community.org/groups/contributors-15/contributors-1545495).

The script used for populating weblate is calling that function which does not return v17.0 branch (https://github.com/OCA/oca-weblate-deployment/blob/75ad176738d15ac2d99aaf0311e31036e39e74d9/wocg-oca#L12C21-L12C50) 

According to https://github.com/OCA/maintainer-tools/pull/539 MAIN_BRANCHES was deprecated and should not be used anymore, so I remove it from default parameter.

With this change, 17.0 branches are properly returned.