### PR TITLE
[ADD] oca.recipe.odoo and repo-maintainer* as not addon repos

### DIFF
--- a/tools/config.py
+++ b/tools/config.py
@@ -49,6 +49,7 @@ NOT_ADDONS = {
     "maintainer-quality-tools",
     "maintainer-tools",
     "mirrors-flake8",
+    "oca.recipe.odoo",
     "oca-addons-repo-template",
     "oca-ci",
     "oca-custom",
@@ -66,6 +67,8 @@ NOT_ADDONS = {
     "OpenUpgrade",
     "openupgradelib",
     "pylint-odoo",
+    "repo-maintainer",
+    "repo-maintainer-conf",
 }
 
 


### PR DESCRIPTION
The 3 following OCA repos are not addons repos and should be added to the corresponding list so that they are not retrieved by other scripts looking for addons :

- oca.recipe.odoo
- repo-maintainer
- repo-maintainer-conf