### PR TITLE
Improve gh login

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Set and store the token to be used for Github auth using:
 
 Alternatively, the token can be set on the GITHUB_TOKEN environment variable.
 
+As a third alternative, if you have the [gh](https://cli.github.com/) client installed
+and have authenticated with `gh auth login`, maintainer tools will attempt to obtain the
+token from it using `gh auth token`.
 
 ### Sync team users from community.odoo.com to GitHub teams
 

--- a/tools/github_login.py
+++ b/tools/github_login.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, print_function
 
 import argparse
 import os
+import subprocess
 from getpass import getpass
 import github3
 from .config import read_config, write_config
@@ -19,6 +20,14 @@ def login():
     else:
         config = read_config()
         token = config.get("GitHub", "token")
+        if not token:
+            try:
+                # attempt to get token from gh
+                token = subprocess.check_output(
+                    ["gh", "auth", "token"], text=True
+                ).strip()
+            except subprocess.SubprocessError:
+                pass
     if not token:
         raise GitHubLoginError(
             "No token has been generated for this script. "


### PR DESCRIPTION
Use `gh auth token` as a third source of GitHub token
