### PR TITLE
oca-gen-addon-readme: delete pandoc installer

### DIFF
--- a/tools/gen_addon_readme.py
+++ b/tools/gen_addon_readme.py
@@ -131,7 +131,7 @@ PANDOC_MARKDOWN_FORMAT = "gfm-raw_html-gfm_auto_identifiers"
 
 @functools.lru_cache(maxsize=None)
 def ensure_pandoc_installed() -> None:
-    pypandoc.ensure_pandoc_installed()
+    pypandoc.ensure_pandoc_installed(delete_installer=True)
 
 
 def make_runboat_badge(repo, branch):


### PR DESCRIPTION
- when pandoc is not available in PATH, [`ensure_pandoc_installed`](https://github.com/JessicaTegner/pypandoc/blob/1341920fa1c1ce661a0ac22138ce819eb73d9f77/pypandoc/__init__.py#L821) downloads its installer in current directory and unpacks it
- one might question that intrusive behavior; in our case we can consider it as beginner friendly
- we just need to delete the installer to avoid polluting repos  
 
fixes #619 