### PR TITLE
[FIX] oca-gen-addon-readme: don't assume index.html encoding

### DIFF
--- a/tools/gen_addon_readme.py
+++ b/tools/gen_addon_readme.py
@@ -408,8 +408,8 @@ def gen_one_addon_index(readme_filename):
     index_dir = os.path.join(addon_dir, "static", "description")
     index_filename = os.path.join(index_dir, "index.html")
     if os.path.exists(index_filename):
-        with open(index_filename) as f:
-            if "oca-gen-addon-readme" not in f.read():
+        with open(index_filename, "rb") as f:
+            if b"oca-gen-addon-readme" not in f.read():
                 # index was created manually
                 return
     if not os.path.isdir(index_dir):


### PR DESCRIPTION
Following a report from a Windows user on discord.