### PR TITLE
oca-towncrier: Use correct title level

### DIFF
--- a/tests/test_towncrier.py
+++ b/tests/test_towncrier.py
@@ -97,7 +97,7 @@ def test_oca_towncrier_md(tmp_path):
         """\
             ## 14.0.1.0.1 (2021-12-31)
 
-            #### Bugfixes
+            ### Bugfixes
 
             - Bugfix description. ([#50](https://github.com/OCA/therepo/issues/50))
         """

--- a/tools/towncrier-template.md
+++ b/tools/towncrier-template.md
@@ -13,7 +13,7 @@
 
 {% if sections[section] %}
 {% for category, val in definitions.items() if category in sections[section] %}
-#### {{ definitions[category]['name'] }}
+### {{ definitions[category]['name'] }}
 
 {% if definitions[category]['showcontent'] %}
 {% for text, values in sections[section][category].items() %}


### PR DESCRIPTION
Use of the correct title level when generating the history into md format

This is required to fix https://github.com/OCA/rest-framework/pull/453#issuecomment-2385509745

ping @sbidoul 