### PR TITLE
gen-addon-readme: consistency between words "license" and "licence"

### DIFF
--- a/tests/test_repo/__unported__/module3/README.rst
+++ b/tests/test_repo/__unported__/module3/README.rst
@@ -1,4 +1,4 @@
-.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.svg
    :target: https://www.gnu.org/licenses/agpl
    :alt: License: AGPL-3
 

--- a/tests/test_repo/module1/README.rst
+++ b/tests/test_repo/module1/README.rst
@@ -1,4 +1,4 @@
-.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.svg
    :target: https://www.gnu.org/licenses/agpl
    :alt: License: AGPL-3
 

--- a/tests/test_repo/module2/README.rst
+++ b/tests/test_repo/module2/README.rst
@@ -1,4 +1,4 @@
-.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.svg
    :target: https://www.gnu.org/licenses/agpl
    :alt: License: AGPL-3
 

--- a/tools/gen_addon_readme.py
+++ b/tools/gen_addon_readme.py
@@ -51,17 +51,17 @@ FRAGMENTS = {
 
 LICENSE_BADGES = {
     "AGPL-3": (
-        "https://img.shields.io/badge/licence-AGPL--3-blue.png",
+        "https://img.shields.io/badge/license-AGPL--3-blue.png",
         "http://www.gnu.org/licenses/agpl-3.0-standalone.html",
         "License: AGPL-3",
     ),
     "LGPL-3": (
-        "https://img.shields.io/badge/licence-LGPL--3-blue.png",
+        "https://img.shields.io/badge/license-LGPL--3-blue.png",
         "http://www.gnu.org/licenses/lgpl-3.0-standalone.html",
         "License: LGPL-3",
     ),
     "GPL-3": (
-        "https://img.shields.io/badge/licence-GPL--3-blue.png",
+        "https://img.shields.io/badge/license-GPL--3-blue.png",
         "http://www.gnu.org/licenses/gpl-3.0-standalone.html",
         "License: GPL-3",
     ),


### PR DESCRIPTION
Before this commit, "license" was used in:
- Image's alternative text
- License URL.

While "licence" was only used in the badge's text.

To be consistent, "license" is now used everywhere. We're preferring that form because:
- It's the way licenses are referred to in their actual names and content (e.g. "GNU Affero General Public License").
- License file is called `LICENSE`.
- The Manifest key of Odoo modules is called that way.

### Milestone (Odoo version)
- 

### Module(s)
- 

### Fixes / new features
- 
