### PR TITLE
[IMP] Render all maintainer avatars in same size

### DIFF
--- a/tests/test_repo/README.md.expected
+++ b/tests/test_repo/README.md.expected
@@ -13,7 +13,7 @@ Available addons
 ----------------
 addon | version | maintainers | summary
 --- | --- | --- | ---
-[module1](module1/) | 8.0.1.0.0 | [![sbidoul](https://github.com/sbidoul.png?size=30px)](https://github.com/sbidoul) | Module 1 summary
+[module1](module1/) | 8.0.1.0.0 | <a href='https://github.com/sbidoul'><img src='https://github.com/sbidoul.png' width='32' height='32' style='border-radius:50%;' alt='sbidoul'/></a> | Module 1 summary
 
 
 Unported addons

--- a/tools/gen_addons_table.py
+++ b/tools/gen_addons_table.py
@@ -31,7 +31,6 @@ from .gitutils import commit_if_needed
 
 _logger = logging.getLogger(__name__)
 
-
 MARKERS = r"(\[//\]: # \(addons\))|(\[//\]: # \(end addons\))"
 MANIFESTS = ("__openerp__.py", "__manifest__.py")
 
@@ -55,9 +54,9 @@ def render_maintainers(manifest):
     maintainers = manifest.get("maintainers") or []
     return " ".join(
         [
-            "[![{maintainer}]"
-            "(https://github.com/{maintainer}.png?size=30px)]"
-            "(https://github.com/{maintainer})".format(maintainer=x)
+            "<a href='https://github.com/{0}'>"
+            "<img src='https://github.com/{0}.png' width='32' height='32' style='border-radius:50%;' alt='{0}'/>"
+            "</a>".format(x)
             for x in maintainers
         ]
     )


### PR DESCRIPTION
### Description
This PR improves how maintainer avatars are rendered in the generated README table.

### Current behavior
When a maintainer does not have a custom GitHub avatar, their image appears larger than others. This creates a visual inconsistency that affects readability and aesthetics.

### Desired behavior after this PR
All maintainer avatars are rendered at a fixed size (32x32px) using HTML <img> tags with a border-radius: 50% style to enforce a modern, consistent round shape.

This ensures a cleaner and more polished appearance for the table, regardless of whether the user has a custom avatar or not.
