### PR TITLE
Fix CI, drop support for python 3.6 and 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,17 +20,19 @@ jobs:
       matrix:
         include:
           - python-version: "3.6"
-            machine: ubuntu-20.04
+            machine: ubuntu-22.04
           - python-version: "3.7"
-            machine: ubuntu-20.04
+            machine: ubuntu-22.04
           - python-version: "3.8"
-            machine: ubuntu-20.04
+            machine: ubuntu-22.04
           - python-version: "3.10"
-            machine: ubuntu-22.04
+            machine: ubuntu-24.04
           - python-version: "3.11"
-            machine: ubuntu-22.04
+            machine: ubuntu-24.04
           - python-version: "3.12"
-            machine: ubuntu-22.04
+            machine: ubuntu-24.04
+          - python-version: "3.13"
+            machine: ubuntu-24.04
     steps:
       - uses: "actions/checkout@v4"
       - uses: "actions/setup-python@v5"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: "3.6"
-            machine: ubuntu-22.04
-          - python-version: "3.7"
-            machine: ubuntu-22.04
           - python-version: "3.8"
             machine: ubuntu-22.04
           - python-version: "3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "setuptools-odoo",  # for oca-gen-external-dependencies
     "whool",  # for oca-gen-external-dependencies
 ]
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ envlist =
     py310
     py311
     py312
+    py313
 
 [testenv]
 skip_missing_interpreters = True
@@ -28,3 +29,4 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@
 
 [tox]
 envlist = 
-    py36
     py38
     py39
     py310
@@ -23,7 +22,6 @@ deps =
 
 [gh-actions]
 python =
-    3.6: py36
     3.8: py38
     3.9: py39
     3.10: py310


### PR DESCRIPTION
Add Python 3.13.

Don't use retired Ubuntu 20 runner

Drop support for old Pythons not available in CI.