### PR TITLE
update-pre-commit-config: add .gitignore support

### DIFF
--- a/tools/update_pre_commit_excluded_addons.py
+++ b/tools/update_pre_commit_excluded_addons.py
@@ -6,6 +6,7 @@ import click
 
 PRE_COMMIT_FILE_PATH = ".pre-commit-config.yaml"
 COVERAGE_FILE_PATH = ".coveragerc"
+GITIGNORE_FILE_PATH = ".gitignore"
 PRE_COMMIT_EXCLUDE_SEPARATOR = "# NOT INSTALLABLE ADDONS"
 PRE_COMMIT_EXCLUDE_SEPARATOR_END = "# END NOT INSTALLABLE ADDONS"
 
@@ -108,6 +109,12 @@ def main(addons_dir):
             # END NOT INSTALLABLE ADDONS
     ..
 
+    In .gitignore
+
+    .. code-block:: text
+        # NOT INSTALLABLE ADDONS
+        # END NOT INSTALLABLE ADDONS
+
     """
     not_installable_addons_dir = []
     addons = os.listdir(addons_dir or ".")
@@ -121,6 +128,9 @@ def main(addons_dir):
     )
     update_not_installable_addons_dir_in_file(
         not_installable_addons_dir, COVERAGE_FILE_PATH, "{addon_dir}/*", "\n"
+    )
+    update_not_installable_addons_dir_in_file(
+        not_installable_addons_dir, GITIGNORE_FILE_PATH, "/{addon_dir}", "\n"
     )
 
 


### PR DESCRIPTION
Add uninstallable addons to .gitignore, so search tools that skip .gitignore'd content will not have search results polluted by code that is uninstallable.

This takes place only when the placeholders is already present in the `.gitignore` file, as it is done for the coverage and pre-commit config.