### PR TITLE
[FIX] Hide OCA banner image, if it's not an OCA repo.

### DIFF
--- a/tests/data/readme_tests/addon1/README.expected-acme.rst
+++ b/tests/data/readme_tests/addon1/README.expected-acme.rst
@@ -1,7 +1,3 @@
-.. image:: https://odoo-community.org/readme-banner-image
-   :target: https://odoo-community.org/get-involved?utm_source=readme
-   :alt: Odoo Community Association
-
 =======
 addon 1
 =======

--- a/tests/data/readme_tests/addon_one_maintainer/README.expected-acme.rst
+++ b/tests/data/readme_tests/addon_one_maintainer/README.expected-acme.rst
@@ -1,7 +1,3 @@
-.. image:: https://odoo-community.org/readme-banner-image
-   :target: https://odoo-community.org/get-involved?utm_source=readme
-   :alt: Odoo Community Association
-
 ====================
 addon one maintainer
 ====================

--- a/tests/data/readme_tests/addon_two_maintainers/README.expected-acme.rst
+++ b/tests/data/readme_tests/addon_two_maintainers/README.expected-acme.rst
@@ -1,7 +1,3 @@
-.. image:: https://odoo-community.org/readme-banner-image
-   :target: https://odoo-community.org/get-involved?utm_source=readme
-   :alt: Odoo Community Association
-
 ====================
 addon one maintainer
 ====================

--- a/tools/gen_addon_readme.rst.jinja
+++ b/tools/gen_addon_readme.rst.jinja
@@ -6,11 +6,13 @@
 {{ fragments[name] }}
 {% endif %}
 {%- endmacro -%}
+{% if org_name == 'OCA' -%}
 
 .. image:: https://odoo-community.org/readme-banner-image
    :target: https://odoo-community.org/get-involved?utm_source=readme
    :alt: Odoo Community Association
 
+{% endif -%}
 {{ '=' * manifest.name|length }}
 {{ manifest.name }}
 {{ '=' * manifest.name|length }}


### PR DESCRIPTION
Rational: this tool can be used for repo out of OCA context. For the time being, a big OCA banner is displayed in all description of modules. This gives the impression that the module was developed by the OCA and complies with OCA standards. (quality, stability, etc.), which is not true.
This commit so removes the OCA banner in such situation. (similar as in the end of the template, with the sentence 'To learn how please visit https://odoo-community.org/page/Contribute.').

Ex : https://github.com/grap/grap-odoo-custom/tree/16.0/fermente_web_environment_ribbon
