### PR TITLE
[IMP] gen_addon_readme: fail if DESCRIPTION fragment is missing

### DIFF
--- a/tests/test_gen_addon_readme.py
+++ b/tests/test_gen_addon_readme.py
@@ -131,6 +131,52 @@ def test_gen_addon_readme_acme(addons_dir):
     _assert_expected(addons_dir, "acme")
 
 
+def test_required_description_fails(tmp_path):
+    addon_dir = tmp_path / "addon"
+    addon_dir.mkdir()
+    with (addon_dir / "__manifest__.py").open("w") as f:
+        f.write("{'name': 'addon'}")
+    with (addon_dir / "__init__.py").open("w") as f:
+        pass
+    cmd = [
+        sys.executable,
+        "-m",
+        "tools.gen_addon_readme",
+        "--addon-dir",
+        str(addon_dir),
+        "--repo-name",
+        "server-tools",
+        "--branch",
+        "12.0",
+    ]
+    with pytest.raises(subprocess.CalledProcessError) as exc:
+        subprocess.check_output(cmd, stderr=subprocess.STDOUT, universal_newlines=True)
+    assert "Addons missing DESCRIPTION" in exc.value.output
+    assert "--no-require-description" in exc.value.output
+
+
+def test_no_require_description_passes(tmp_path):
+    addon_dir = tmp_path / "addon"
+    addon_dir.mkdir()
+    with (addon_dir / "__manifest__.py").open("w") as f:
+        f.write("{'name': 'addon'}")
+    with (addon_dir / "__init__.py").open("w") as f:
+        pass
+    cmd = [
+        sys.executable,
+        "-m",
+        "tools.gen_addon_readme",
+        "--addon-dir",
+        str(addon_dir),
+        "--repo-name",
+        "server-tools",
+        "--branch",
+        "12.0",
+        "--no-require-description",
+    ]
+    subprocess.check_call(cmd)
+
+
 def test_rst_error(tmp_path):
     addon_dir = tmp_path / "addon"
     addon_dir.mkdir()

--- a/tools/gen_addon_readme.py
+++ b/tools/gen_addon_readme.py
@@ -518,6 +518,12 @@ def _get_source_digest(readme_filename: str) -> Union[str, None]:
     is_flag=True,
     default=False,
 )
+@click.option(
+    "--require-description/--no-require-description",
+    is_flag=True,
+    default=True,
+    help="Require DESCRIPTION fragment, fail if missing.",
+)
 def gen_addon_readme(
     org_name,
     repo_name,
@@ -530,10 +536,11 @@ def gen_addon_readme(
     if_fragments_changed,
     convert_fragments_to_markdown,
     keep_source_digest,
+    require_description,
 ):
     """Generate README.rst from fragments.
 
-    Do nothing if readme/DESCRIPTION(.rst|.md) is absent, otherwise overwrite
+    Raises an error if readme/DESCRIPTION(.rst|.md) is absent, otherwise overwrite
     existing README.rst with content generated from the template,
     fragments (DESCRIPTION(.rst|.md), USAGE(.rst|.md), etc) and the addon manifest.
     """
@@ -548,10 +555,13 @@ def gen_addon_readme(
             continue
         addons.append((addon_name, addon_dir, manifest))
     readme_filenames = []
+    addons_without_readme = []
     for addon_name, addon_dir, manifest in addons:
         if convert_fragments_to_markdown:
             convert_fragments_to_md(addon_dir)
         if not fragment_exists(addon_dir, "DESCRIPTION"):
+            if require_description:
+                addons_without_readme.append(addon_name)
             continue
         readme_filename = os.path.join(addon_dir, "README.rst")
         source_digest = hash(
@@ -585,6 +595,10 @@ def gen_addon_readme(
             )
             if index_filename:
                 readme_filenames.append(index_filename)
+    if addons_without_readme:
+        raise click.ClickException(
+            f"Addons missing DESCRIPTION: {addons_without_readme}\nTo skip this check, use --no-require-description"
+        )
     if commit:
         commit_if_needed(readme_filenames, "[UPD] README.rst")
 


### PR DESCRIPTION
Fixes #590

### Problem
`oca-gen-addon-readme` silently skipped addons without `readme/DESCRIPTION(.rst|.md)` 
(`tools/gen_addon_readme.py:562` `continue`), exiting with code 0. The pre-commit 
hook stayed green and modules could be left without README, as in 
OCA/sale-workflow#2771.

Relevant discussion: https://github.com/OCA/maintainer-tools/issues/590

### Solution
- Require `DESCRIPTION` by default. Collect all addons missing it and fail with
  `click.ClickException` listing them.
- Add `--require-description / --no-require-description` (default `True`) to
  skip the check when needed. Hint is included in the error:
  `To skip this check, use --no-require-description`.
- Update docstring (`Do nothing if ...` → `Raises an error if ...`).
- Scope is intentionally limited to `DESCRIPTION` only, per @pedrobaeza 
  ("For me the only mandatory one should be DESCRIPTION") and @sbidoul
  ("we can now fail pre-commit if the main README fragments are not present").

Not in scope: `USAGE`/`CONTEXT` (debated in #590, left for a follow-up).

### Testing
- `test_required_description_fails`: addon without DESCRIPTION → fails and
  mentions both `Addons missing DESCRIPTION` and `--no-require-description`
- `test_no_require_description_passes`: same addon with `--no-require-description`
  → passes
- Existing tests: `test_rst_error`, `test_get_fragment_format`, etc. still pass.
  `test_gen_addon_readme_oca/acme` failures are pre-existing (docutils mismatch,
  reproduced on `origin/master` without this change).

### Checklist
- [x] Rebased on `origin/master` (`f9e5ae4`)
- [x] `help` text added for the new flag